### PR TITLE
fix: Track token usage from decomposition LLM call

### DIFF
--- a/gemicro-core/src/agent.rs
+++ b/gemicro-core/src/agent.rs
@@ -305,7 +305,7 @@ async fn decompose(
         .await
         .map_err(|e| AgentError::DecompositionFailed(e.to_string()))?;
 
-    // Extract token count before parsing
+    // Extract token count before consuming response text for parsing
     let tokens_used = response.tokens_used;
 
     // Parse JSON response


### PR DESCRIPTION
## Summary

- Track token usage from the decomposition phase LLM call, enabling complete token accounting
- Closes #17

## Changes

- Modify `decompose()` to return `(Vec<String>, Option<u32>)` tuple
- Extract `tokens_used` from `LlmResponse` before parsing sub-queries
- Add decomposition tokens to `total_tokens` in `execute()` metadata calculation
- Follow existing pattern for graceful degradation (`tokens_unavailable_count` incremented if `None`)

## Before

Only sub-query execution and synthesis tokens were counted:
```
Total tokens: 1608  (sub-queries only)
```

## After

All three phases now contribute to total:
```
Total tokens: 2643  (decomposition + sub-queries + synthesis)
```

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes (124 tests)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] Integration test verifies tokens are tracked end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)