### PR TITLE
chore: Add #[non_exhaustive] to ResearchPrompts

### DIFF
--- a/gemicro-core/src/config.rs
+++ b/gemicro-core/src/config.rs
@@ -27,6 +27,7 @@ pub const MODEL: &str = "gemini-3-flash-preview";
 /// assert!(rendered.contains("What causes migraines?"));
 /// ```
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ResearchPrompts {
     /// System instruction for decomposition phase
     pub decomposition_system: String,


### PR DESCRIPTION
## Summary
Adds `#[non_exhaustive]` attribute to `ResearchPrompts` struct to allow future field additions without breaking changes.

## Changes
- Add `#[non_exhaustive]` attribute to `ResearchPrompts` struct

## Trade-offs
- **Pro**: Allows adding new prompt fields without semver major version bump
- **Con**: Users must use `..Default::default()` instead of exhaustive struct literals

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)