### PR TITLE
docs: Document why sub_query_system has no template

### DIFF
--- a/gemicro-core/src/config.rs
+++ b/gemicro-core/src/config.rs
@@ -38,6 +38,10 @@ pub struct ResearchPrompts {
     pub decomposition_template: String,
 
     /// System instruction for sub-query execution phase
+    ///
+    /// Note: Unlike decomposition and synthesis, sub-queries do not use a template.
+    /// The sub-question text is passed directly as the user prompt, while this
+    /// system instruction is shared across all parallel sub-query executions.
     pub sub_query_system: String,
 
     /// System instruction for synthesis phase


### PR DESCRIPTION
## Summary
Adds documentation explaining why `sub_query_system` doesn't have a corresponding `_template` field like decomposition and synthesis.

## Context
The `ResearchPrompts` struct has an intentional asymmetry:
- `decomposition_system` + `decomposition_template` (with placeholders)
- `sub_query_system` (no template)
- `synthesis_system` + `synthesis_template` (with placeholders)

This is correct because sub-queries pass the sub-question text directly as the user prompt, while the system instruction is shared across all parallel executions.

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)