### PR TITLE
feat: Add placeholder validation to ResearchPrompts::validate()

### DIFF
--- a/gemicro-core/src/config.rs
+++ b/gemicro-core/src/config.rs
@@ -612,4 +612,27 @@ mod tests {
         };
         assert!(prompts.validate().is_ok());
     }
+
+    #[test]
+    fn test_research_prompts_validation_case_sensitive_placeholders() {
+        // Placeholder matching is case-sensitive - {Query} is not the same as {query}
+        let prompts = ResearchPrompts {
+            decomposition_template: "{min} to {max}: {Query}".to_string(), // Wrong case
+            ..Default::default()
+        };
+        let result = prompts.validate();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("{query}"));
+
+        // Same for synthesis template
+        let prompts = ResearchPrompts {
+            synthesis_template: "{Query} -> {Findings}".to_string(), // Wrong case
+            ..Default::default()
+        };
+        let result = prompts.validate();
+        assert!(result.is_err());
+        // Should fail on first missing placeholder ({query} or {findings})
+        let err = result.unwrap_err();
+        assert!(err.contains("{query}") || err.contains("{findings}"));
+    }
 }


### PR DESCRIPTION
## Summary

- Adds validation that `decomposition_template` contains `{min}`, `{max}`, and `{query}`
- Adds validation that `synthesis_template` contains `{query}` and `{findings}`
- Catches configuration errors at construction time rather than runtime
- Adds 6 new test cases covering all placeholder validation scenarios

## Test plan

- [x] All 162 tests pass
- [x] Clippy clean
- [x] Format check passes

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)