### PR TITLE
refactor: Change validation methods to return Result<(), AgentError>

### DIFF
--- a/gemicro-core/src/agent.rs
+++ b/gemicro-core/src/agent.rs
@@ -260,7 +260,7 @@ impl DeepResearchAgent {
     ///
     /// Returns `AgentError::InvalidConfig` if the configuration is invalid.
     pub fn new(config: ResearchConfig) -> Result<Self, AgentError> {
-        config.validate().map_err(AgentError::InvalidConfig)?;
+        config.validate()?;
         Ok(Self { config })
     }
 


### PR DESCRIPTION
## Summary

- Changes `ResearchPrompts::validate()` to return `Result<(), AgentError>`
- Changes `ResearchConfig::validate()` to return `Result<(), AgentError>`
- Eliminates manual error conversion with `.map_err(AgentError::InvalidConfig)` at call sites
- Better alignment with project error handling architecture

## Test plan

- [x] All 158 tests pass
- [x] Clippy clean
- [x] Format check passes

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)