### PR TITLE
feat: Add Google Search grounding support for real-time web data

### DIFF
--- a/gemicro-cli/src/cli.rs
+++ b/gemicro-cli/src/cli.rs
@@ -60,6 +60,14 @@ pub struct Args {
     /// Use plain text output instead of markdown rendering
     #[arg(long)]
     pub plain: bool,
+
+    /// Enable Google Search grounding for real-time web data
+    ///
+    /// When enabled, sub-queries can search the web to ground responses
+    /// in real-time information. Useful for current events, recent releases,
+    /// or live data. Note: May have different pricing.
+    #[arg(long)]
+    pub google_search: bool,
 }
 
 impl Args {
@@ -138,6 +146,7 @@ impl Args {
             max_concurrent_sub_queries: self.max_concurrent,
             continue_on_partial_failure: self.continue_on_failure,
             total_timeout: Duration::from_secs(self.timeout),
+            use_google_search: self.google_search,
             ..Default::default()
         }
     }
@@ -163,6 +172,7 @@ mod tests {
             temperature: 0.7,
             verbose: false,
             plain: false,
+            google_search: false,
         }
     }
 

--- a/gemicro-core/src/agent.rs
+++ b/gemicro-core/src/agent.rs
@@ -571,6 +571,7 @@ async fn execute_parallel(
         let sub_query_system = config.prompts.sub_query_system.clone();
         let semaphore = semaphore.clone();
         let cancellation_token = context.cancellation_token.clone();
+        let use_google_search = config.use_google_search;
 
         tokio::spawn(async move {
             // Acquire semaphore permit if concurrency is limited.
@@ -582,7 +583,10 @@ async fn execute_parallel(
                 None => None,
             };
 
-            let request = LlmRequest::with_system(&query, &sub_query_system);
+            let mut request = LlmRequest::with_system(&query, &sub_query_system);
+            if use_google_search {
+                request = request.with_google_search();
+            }
 
             // Execute LLM call with cancellation support
             let result = match llm

--- a/gemicro-core/src/config.rs
+++ b/gemicro-core/src/config.rs
@@ -173,6 +173,16 @@ pub struct ResearchConfig {
     /// Default: 60 seconds
     pub total_timeout: Duration,
 
+    /// Enable Google Search grounding for sub-queries
+    ///
+    /// When enabled, sub-queries can search the web for real-time information.
+    /// This is useful for queries about current events, recent releases, or live data.
+    ///
+    /// Note: Grounded requests may have different pricing.
+    ///
+    /// Default: false
+    pub use_google_search: bool,
+
     /// Prompts for the research agent
     ///
     /// Default: Built-in prompts optimized for Gemini
@@ -222,6 +232,7 @@ impl Default for ResearchConfig {
             max_concurrent_sub_queries: 5,
             continue_on_partial_failure: true,
             total_timeout: Duration::from_secs(60),
+            use_google_search: false,
             prompts: ResearchPrompts::default(),
         }
     }


### PR DESCRIPTION
## Summary

Implements Google Search grounding for sub-queries in the Deep Research agent.

- Add `use_google_search` field to `LlmRequest` with `with_google_search()` builder
- Add `use_google_search` field to `ResearchConfig`
- Pass google_search flag to LLM requests in parallel execution
- Add `--google-search` CLI flag to enable grounding

## Usage

```bash
# Enable web search grounding for real-time data
gemicro --google-search "What are the latest AI developments in 2024?"
```

When enabled, sub-queries can search the web for real-time information. Useful for:
- Current events
- Recent software releases
- Live data (prices, weather, etc.)

## Note

Grounded requests may have different pricing than regular requests.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)