### PR TITLE
test: Add remaining quick win tests and fix rust-genai API change

### DIFF
--- a/gemicro-core/src/llm.rs
+++ b/gemicro-core/src/llm.rs
@@ -506,7 +506,7 @@ impl LlmClient {
         }
 
         if request.use_google_search {
-            interaction = interaction.with_google_search();
+            interaction = interaction.with_tools(vec![rust_genai::Tool::GoogleSearch]);
         }
 
         interaction


### PR DESCRIPTION
## Summary

This PR consolidates the remaining changes from closed PRs #51 and #55, along with a fix for a rust-genai API breaking change:

### Changes

- **Placeholder validation** (Issue #23)
  - Added validation to `ResearchPrompts::validate()` for required placeholders
  - Validates `{min}`, `{max}`, `{query}` in decomposition_template
  - Validates `{query}`, `{findings}` in synthesis_template
  - Case-sensitive placeholder matching
  - Added comprehensive tests for all placeholder validation scenarios

- **Edge case tests** (Issue #16)
  - `truncate_for_error`: empty string, zero max_chars, exact boundary, unicode (emoji, CJK, mixed)
  - `parse_json_array`: nested arrays, mixed types, null values, large arrays, unicode content, escaped quotes
  - Error display tests for all `AgentError` variants

- **rust-genai API fix**
  - Updated `with_google_search()` → `with_tools(vec![Tool::GoogleSearch])` to match upstream API changes

## Test plan

- [x] All 201 tests pass (`cargo test --workspace`)
- [x] Clippy clean (`cargo clippy --workspace -- -D warnings`)
- [x] Format check passes (`cargo fmt --all -- --check`)

Closes #23, #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)