### PR TITLE
fix: Use exact placeholder matching to prevent substring false positives

### DIFF
--- a/gemicro-core/src/config.rs
+++ b/gemicro-core/src/config.rs
@@ -125,8 +125,9 @@ fn validate_template_placeholders(
 ///
 /// Template placeholders do **not** support brace escaping. If your template
 /// contains literal `{` or `}` characters, they will be interpreted as
-/// placeholder delimiters. There is currently no escape sequence to include
-/// literal braces in templates.
+/// placeholder delimiters. Nested braces (e.g., `{{name}}`) will extract
+/// the innermost placeholder (`{name}`). There is currently no escape sequence
+/// to include literal braces in templates.
 ///
 /// # Example
 ///


### PR DESCRIPTION
## Summary

Addresses code review feedback from PR #38:

- **Bug fix**: `validate_template_placeholders()` now uses `extract_placeholders()` for exact matching instead of `str::contains()`, which had substring false positives (e.g., `{minimum}` incorrectly satisfying `{min}` requirement)
- **Documentation**: Added rustdoc examples showing nested brace behavior
- **Tests**: 4 new tests covering substring false positives and nested brace edge cases

## Test plan

- [x] `cargo test --workspace` passes (120 config tests, +4 new)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

## Changes

| File | Change |
|------|--------|
| `gemicro-core/src/config.rs` | Fix validation logic, add docs & tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)