### PR TITLE
fix: Address remaining code review feedback

### DIFF
--- a/gemicro-cli/src/display/mod.rs
+++ b/gemicro-cli/src/display/mod.rs
@@ -12,6 +12,5 @@ pub use indicatif::IndicatifRenderer;
 pub use renderer::Renderer;
 
 // Re-export execution state types from gemicro-runner
-// DisplayState is an alias for backwards compatibility
-pub use gemicro_runner::ExecutionState as DisplayState;
+pub use gemicro_runner::ExecutionState;
 pub use gemicro_runner::Phase;

--- a/gemicro-cli/src/main.rs
+++ b/gemicro-cli/src/main.rs
@@ -7,7 +7,7 @@ mod repl;
 
 use anyhow::{bail, Context, Result};
 use clap::Parser;
-use display::{DisplayState, IndicatifRenderer, Phase, Renderer};
+use display::{ExecutionState, IndicatifRenderer, Phase, Renderer};
 use futures_util::StreamExt;
 use gemicro_core::{AgentContext, AgentError, DeepResearchAgent, LlmClient};
 use repl::Session;
@@ -85,7 +85,7 @@ async fn run_research(args: &cli::Args, query: &str) -> Result<()> {
         .context("Failed to create research agent")?;
 
     // Initialize state and renderer
-    let mut state = DisplayState::new();
+    let mut state = ExecutionState::new();
     let mut renderer = IndicatifRenderer::new(args.plain);
 
     // Set up interrupt handling with AtomicU8 for cross-thread visibility.

--- a/gemicro-cli/src/repl/session.rs
+++ b/gemicro-cli/src/repl/session.rs
@@ -4,7 +4,7 @@
 
 use super::commands::Command;
 use super::registry::AgentRegistry;
-use crate::display::{DisplayState, IndicatifRenderer, Phase, Renderer};
+use crate::display::{ExecutionState, IndicatifRenderer, Phase, Renderer};
 use crate::format::truncate;
 use anyhow::{Context, Result};
 use futures_util::StreamExt;
@@ -116,7 +116,7 @@ impl Session {
         };
 
         // Initialize state and renderer
-        let mut state = DisplayState::new();
+        let mut state = ExecutionState::new();
         let mut renderer = IndicatifRenderer::new(self.plain);
         let mut events = Vec::new();
 

--- a/gemicro-runner/Cargo.toml
+++ b/gemicro-runner/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gemicro-runner"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.56"
 description = "Headless execution runtime for gemicro agents"
 
 [dependencies]

--- a/gemicro-runner/src/runner.rs
+++ b/gemicro-runner/src/runner.rs
@@ -36,6 +36,7 @@ use gemicro_core::{Agent, AgentContext, AgentError};
 /// # Ok(())
 /// # }
 /// ```
+#[derive(Debug, Clone, Copy)]
 pub struct AgentRunner;
 
 impl AgentRunner {

--- a/gemicro-runner/src/state.rs
+++ b/gemicro-runner/src/state.rs
@@ -99,6 +99,17 @@ impl ExecutionState {
     /// Update state from an AgentUpdate event.
     ///
     /// Returns the ID of the sub-query that was updated, if any.
+    ///
+    /// # Error Handling
+    ///
+    /// This method follows the Evergreen philosophy of graceful degradation:
+    /// - **Unknown event types** are logged at debug level and ignored
+    /// - **Malformed event data** is logged at warn level and ignored
+    ///
+    /// The state machine continues processing subsequent events even if some
+    /// events are malformed. This ensures robustness against protocol evolution
+    /// and partial failures, but callers should monitor logs if strict validation
+    /// is required.
     pub fn update(&mut self, event: &AgentUpdate) -> Option<usize> {
         match event.event_type.as_str() {
             EVENT_DECOMPOSITION_STARTED => {


### PR DESCRIPTION
## Summary

Addresses remaining feedback from PR #66 code review.

**Breaking changes:**
- Remove `DisplayState` alias - use `ExecutionState` directly

**Improvements:**
- **#4**: Document silent error handling behavior in `ExecutionState::update()`
- **#5**: Change `SubQueryTiming.succeeded` from `bool` to `Option<bool>`
  - `Some(true)` = completed successfully
  - `Some(false)` = failed with error
  - `None` = still in progress (pending/executing)
- **#8**: Add `#[derive(Debug, Clone, Copy)]` to `AgentRunner`
- **#10**: Add `rust-version = "1.56"` MSRV to Cargo.toml

## Test plan

- [x] All 34 gemicro-runner tests pass
- [x] All 50 gemicro-cli tests pass
- [x] Clippy passes with `-D warnings`
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)