### PR TITLE
refactor: Add format_summary() and #[must_use] attributes

### DIFF
--- a/gemicro-eval/src/judge.rs
+++ b/gemicro-eval/src/judge.rs
@@ -79,13 +79,15 @@ impl Default for JudgeConfig {
 }
 
 impl JudgeConfig {
-    /// Create a new config with a custom system instruction
+    /// Create a new config with a custom system instruction.
+    #[must_use]
     pub fn with_system_instruction(mut self, instruction: impl Into<String>) -> Self {
         self.system_instruction = instruction.into();
         self
     }
 
-    /// Set the timeout
+    /// Set the timeout.
+    #[must_use]
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
         self


### PR DESCRIPTION
## Summary

- Add `format_summary()` method to `EvalSummary` for testable string output
- Refactor `print_summary()` to use `format_summary()` as convenience wrapper
- Add `#[must_use]` to `JudgeConfig` builder methods for consistency with `EvalConfig`

## Changes

| File | Change |
|------|--------|
| `gemicro-eval/src/results.rs` | Add `format_summary()` method + test |
| `gemicro-eval/src/judge.rs` | Add `#[must_use]` to builder methods |

## Rationale

**format_summary()**: Separates formatting from I/O, making the summary:
- Testable (can assert on string content)
- Usable in non-CLI contexts (logging, custom output)
- Following separation of concerns

**#[must_use]**: Prevents accidental unused builder calls like:
```rust
config.with_timeout(Duration::from_secs(60)); // Oops, result not used!
```

## Test plan

- [x] All tests pass (42 in gemicro-eval)
- [x] Clippy clean
- [x] Docs build clean
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)