### PR TITLE
test: Add edge case tests for error paths (#16)

### DIFF
--- a/gemicro-core/src/agent/deep_research.rs
+++ b/gemicro-core/src/agent/deep_research.rs
@@ -739,6 +739,15 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_json_array_special_characters() {
+        // Test newlines and tabs in JSON strings
+        let input = r#"["Line1\nLine2", "Tab\there"]"#;
+        let result = parse_json_array(input).unwrap();
+        assert_eq!(result[0], "Line1\nLine2");
+        assert_eq!(result[1], "Tab\there");
+    }
+
+    #[test]
     fn test_parse_json_array_error_message_contains_response() {
         let input = "invalid json here";
         let result = parse_json_array(input);

--- a/gemicro-core/src/error.rs
+++ b/gemicro-core/src/error.rs
@@ -132,4 +132,48 @@ mod tests {
         let err = AgentError::AllSubQueriesFailed;
         assert!(err.to_string().contains("All sub-queries failed"));
     }
+
+    #[test]
+    fn test_parse_failed_display() {
+        let err = AgentError::ParseFailed("Invalid JSON".to_string());
+        let display = err.to_string();
+        assert!(display.contains("parse"));
+        assert!(display.contains("Invalid JSON"));
+    }
+
+    #[test]
+    fn test_synthesis_failed_display() {
+        let err = AgentError::SynthesisFailed("Empty response".to_string());
+        let display = err.to_string();
+        assert!(display.contains("synthesize"));
+        assert!(display.contains("Empty response"));
+    }
+
+    #[test]
+    fn test_cancelled_display() {
+        let err = AgentError::Cancelled;
+        let display = err.to_string();
+        assert!(display.contains("cancelled"));
+    }
+
+    #[test]
+    fn test_timeout_display() {
+        let err = AgentError::Timeout {
+            elapsed_ms: 5000,
+            timeout_ms: 3000,
+            phase: "decomposition".to_string(),
+        };
+        let display = err.to_string();
+        assert!(display.contains("5000"));
+        assert!(display.contains("3000"));
+        assert!(display.contains("decomposition"));
+    }
+
+    #[test]
+    fn test_invalid_config_display() {
+        let err = AgentError::InvalidConfig("min > max".to_string());
+        let display = err.to_string();
+        assert!(display.contains("Invalid configuration"));
+        assert!(display.contains("min > max"));
+    }
 }

--- a/gemicro-core/src/utils.rs
+++ b/gemicro-core/src/utils.rs
@@ -114,6 +114,24 @@ mod tests {
     }
 
     #[test]
+    fn test_truncate_with_count_exact_length() {
+        assert_eq!(truncate_with_count("hello", 5), "hello");
+    }
+
+    #[test]
+    fn test_truncate_with_count_empty_string() {
+        assert_eq!(truncate_with_count("", 10), "");
+    }
+
+    #[test]
+    fn test_truncate_with_count_zero_max() {
+        // Edge case: max_chars = 0 should still work
+        let result = truncate_with_count("hello", 0);
+        assert!(result.contains("..."));
+        assert!(result.contains("5 chars total"));
+    }
+
+    #[test]
     fn test_truncate_with_count_long_string() {
         let long = "a".repeat(100);
         let result = truncate_with_count(&long, 20);


### PR DESCRIPTION
## Summary

Recovers and adapts edge case tests from closed PR #55 (which was closed due to merge conflicts after the codebase was refactored).

**Tests added:**

### utils.rs (truncate_with_count)
- `test_truncate_with_count_exact_length` - boundary condition
- `test_truncate_with_count_empty_string` - empty input handling
- `test_truncate_with_count_zero_max` - edge case with max_chars = 0

### deep_research.rs (parse_json_array)
- `test_parse_json_array_special_characters` - newlines and tabs in JSON strings

### error.rs (AgentError display)
- `test_parse_failed_display` - ParseFailed format validation
- `test_synthesis_failed_display` - SynthesisFailed format validation
- `test_cancelled_display` - Cancelled format validation
- `test_timeout_display` - Timeout with all fields
- `test_invalid_config_display` - InvalidConfig format validation

## Background

The original PR #55 had comprehensive tests but was closed due to merge conflicts when the codebase was restructured (agent.rs split into module directory, truncate utilities consolidated, etc.). These tests have been adapted to work with the current codebase structure.

## Test plan

- [x] All workspace tests pass (`cargo test --workspace`)
- [x] Clippy clean (`cargo clippy --workspace -- -D warnings`)
- [x] Format check passes (`cargo fmt --all -- --check`)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)