### PR TITLE
refactor: Consolidate tests with rstest parameterization

### DIFF
--- a/gemicro-core/Cargo.toml
+++ b/gemicro-core/Cargo.toml
@@ -18,3 +18,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 futures-util = { workspace = true }
 log = { workspace = true }
+
+[dev-dependencies]
+rstest = "0.23"

--- a/gemicro-core/src/agent/mod.rs
+++ b/gemicro-core/src/agent/mod.rs
@@ -378,51 +378,5 @@ mod tests {
         let _context_fn = |llm: LlmClient| AgentContext::new(llm);
     }
 
-    // Error display tests
-
-    #[test]
-    fn test_agent_error_decomposition_failed_display() {
-        let error = AgentError::DecompositionFailed("LLM returned garbage".to_string());
-        let display = error.to_string();
-        assert!(display.contains("decompose"));
-        assert!(display.contains("LLM returned garbage"));
-    }
-
-    #[test]
-    fn test_agent_error_parse_failed_display() {
-        let error = AgentError::ParseFailed("invalid JSON".to_string());
-        let display = error.to_string();
-        assert!(display.contains("parse"));
-        assert!(display.contains("invalid JSON"));
-    }
-
-    #[test]
-    fn test_agent_error_synthesis_failed_display() {
-        let error = AgentError::SynthesisFailed("empty response".to_string());
-        let display = error.to_string();
-        assert!(display.contains("synthesize"));
-        assert!(display.contains("empty response"));
-    }
-
-    #[test]
-    fn test_agent_error_all_sub_queries_failed_display() {
-        let error = AgentError::AllSubQueriesFailed;
-        let display = error.to_string();
-        assert!(display.contains("sub-queries failed"));
-    }
-
-    #[test]
-    fn test_agent_error_cancelled_display() {
-        let error = AgentError::Cancelled;
-        let display = error.to_string();
-        assert!(display.contains("cancelled"));
-    }
-
-    #[test]
-    fn test_agent_error_invalid_config_display() {
-        let error = AgentError::InvalidConfig("min > max".to_string());
-        let display = error.to_string();
-        assert!(display.contains("configuration"));
-        assert!(display.contains("min > max"));
-    }
+    // Note: AgentError display tests are in error.rs to avoid duplication
 }

--- a/gemicro-eval/Cargo.toml
+++ b/gemicro-eval/Cargo.toml
@@ -22,3 +22,4 @@ tokio = { workspace = true, features = ["test-util", "macros"] }
 rust-genai = { workspace = true }
 tempfile = "3.20"
 env_logger = "0.11"
+rstest = "0.23"

--- a/gemicro-runner/Cargo.toml
+++ b/gemicro-runner/Cargo.toml
@@ -16,3 +16,4 @@ log = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }
 rust-genai = { workspace = true }
+rstest = "0.23"

--- a/gemicro-runner/src/utils.rs
+++ b/gemicro-runner/src/utils.rs
@@ -26,20 +26,20 @@ pub fn format_duration(duration: Duration) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
-    #[test]
-    fn test_format_duration_milliseconds() {
-        assert_eq!(format_duration(Duration::from_millis(500)), "500ms");
-    }
-
-    #[test]
-    fn test_format_duration_seconds_under_10() {
-        assert_eq!(format_duration(Duration::from_secs_f64(2.5)), "2.50s");
-    }
-
-    #[test]
-    fn test_format_duration_seconds_over_10() {
-        assert_eq!(format_duration(Duration::from_secs_f64(12.5)), "12.5s");
+    // Parameterized test for duration formatting with boundary cases
+    #[rstest]
+    #[case::zero(Duration::ZERO, "0ms")]
+    #[case::milliseconds(Duration::from_millis(500), "500ms")]
+    #[case::just_under_one_sec(Duration::from_millis(999), "999ms")]
+    #[case::exactly_one_sec(Duration::from_secs(1), "1.00s")]
+    #[case::seconds_under_10(Duration::from_secs_f64(2.5), "2.50s")]
+    #[case::just_under_10_sec(Duration::from_secs_f64(9.99), "9.99s")]
+    #[case::exactly_10_sec(Duration::from_secs(10), "10.0s")]
+    #[case::seconds_over_10(Duration::from_secs_f64(12.5), "12.5s")]
+    fn test_format_duration(#[case] input: Duration, #[case] expected: &str) {
+        assert_eq!(format_duration(input), expected);
     }
 
     // Verify re-exports work


### PR DESCRIPTION
## Summary

Add rstest as dev-dependency and consolidate repetitive tests into parameterized versions.

**Changes:**

### Dependencies
- Add `rstest = "0.23"` to gemicro-core, gemicro-runner, gemicro-eval

### Removed Redundant Tests
- Remove 6 duplicate `AgentError` display tests from `agent/mod.rs` (identical to tests in `error.rs`)

### Consolidated with rstest

| File | Before | After | Cases |
|------|--------|-------|-------|
| `error.rs` | 8 tests | 1 parameterized | 7 error variants |
| `config.rs` | 5 tests | 1 parameterized | 5 placeholder validations |
| `utils.rs` | 3 tests | 1 parameterized | 8 duration formats (adds boundary tests) |
| `scorer.rs` | 15 tests | 3 parameterized | ExactMatch, F1Score, Contains |

### Result
- **Net change:** -131 lines
- **Coverage:** Same + additional boundary tests for duration formatting
- **Test count:** ~35 individual tests → ~25 parameterized test functions

## Test plan

- [x] All tests pass (`cargo test --workspace`)
- [x] Clippy clean
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)