### PR TITLE
fix: Increase max_tokens in test helpers to prevent truncation

### DIFF
--- a/gemicro-core/tests/common/mod.rs
+++ b/gemicro-core/tests/common/mod.rs
@@ -17,14 +17,14 @@ pub fn get_api_key() -> Option<String> {
     env::var("GEMINI_API_KEY").ok()
 }
 
-/// Create a test LlmClient with appropriate timeouts for testing.
+/// Create a test LlmClient with appropriate settings for testing.
 ///
-/// Uses shorter timeouts and lower token counts to keep tests fast.
+/// Uses shorter timeouts and sufficient token limits for reliable responses.
 pub fn create_test_client(api_key: &str) -> LlmClient {
     let genai_client = rust_genai::Client::builder(api_key.to_string()).build();
     let config = LlmConfig {
         timeout: Duration::from_secs(60),
-        max_tokens: 256,
+        max_tokens: 4096,
         temperature: 0.0, // Deterministic for testing
         max_retries: 1,
         retry_base_delay_ms: 500,
@@ -32,14 +32,14 @@ pub fn create_test_client(api_key: &str) -> LlmClient {
     LlmClient::new(genai_client, config)
 }
 
-/// Create a test AgentContext with appropriate timeouts for testing.
+/// Create a test AgentContext with appropriate settings for testing.
 ///
-/// Uses slightly higher token limit than `create_test_client` for agent tests.
+/// Uses sufficient token limits to avoid truncated responses during agent execution.
 pub fn create_test_context(api_key: &str) -> AgentContext {
     let genai_client = rust_genai::Client::builder(api_key.to_string()).build();
     let config = LlmConfig {
         timeout: Duration::from_secs(60),
-        max_tokens: 512,
+        max_tokens: 4096,
         temperature: 0.7,
         max_retries: 1,
         retry_base_delay_ms: 500,
@@ -58,7 +58,7 @@ pub fn create_test_context_with_cancellation(
     let genai_client = rust_genai::Client::builder(api_key.to_string()).build();
     let config = LlmConfig {
         timeout: Duration::from_secs(60),
-        max_tokens: 512,
+        max_tokens: 4096,
         temperature: 0.7,
         max_retries: 1,
         retry_base_delay_ms: 500,


### PR DESCRIPTION
## Summary

- Increase `max_tokens` from 256/512 to 4096 in all test helpers
- Fixes intermittent integration test failures caused by truncated LLM responses
- The decomposition phase was generating arrays of sub-queries that exceeded 512 tokens, causing JSON parse failures

## Test plan

- [x] All unit tests pass (`cargo test --workspace`)
- [x] All integration tests pass (ran successfully during verification)
- [x] Format check passes (`cargo fmt --all -- --check`)
- [x] Clippy passes (`cargo clippy --workspace -- -D warnings`)

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)