### PR TITLE
feat: Add evaluation CLI for running benchmarks

### DIFF
--- a/gemicro-eval/Cargo.toml
+++ b/gemicro-eval/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 description = "Evaluation framework for benchmarking gemicro agents against datasets"
 
+[[bin]]
+name = "gemicro-eval"
+path = "src/bin/main.rs"
+
 [dependencies]
 gemicro-core = { path = "../gemicro-core" }
 gemicro-runner = { path = "../gemicro-runner" }
@@ -16,6 +20,10 @@ log = { workspace = true }
 async-stream = { workspace = true }
 reqwest = { version = "0.12", features = ["json"] }
 dirs = "6.0"
+clap = { version = "4.5", features = ["derive", "env"] }
+indicatif = "0.17"
+rust-genai = { workspace = true }
+env_logger = "0.11"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/gemicro-eval/src/bin/main.rs
+++ b/gemicro-eval/src/bin/main.rs
@@ -1,0 +1,440 @@
+//! Evaluation CLI for benchmarking gemicro agents.
+//!
+//! Run evaluations against HotpotQA or custom JSON datasets.
+
+use clap::Parser;
+use gemicro_core::{
+    DeepResearchAgent, LlmClient, LlmConfig, ReactAgent, ReactConfig, ResearchConfig,
+    SimpleQaAgent, SimpleQaConfig,
+};
+use gemicro_eval::{
+    Contains, Dataset, EvalConfig, EvalHarness, EvalProgress, EvalSummary, ExactMatch, F1Score,
+    HotpotQA, JsonFileDataset, Scorers,
+};
+use gemicro_runner::AgentRegistry;
+use indicatif::{ProgressBar, ProgressStyle};
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::time::Duration;
+
+/// Evaluation CLI for benchmarking gemicro agents.
+#[derive(Parser, Debug)]
+#[command(name = "gemicro-eval")]
+#[command(about = "Run evaluations against HotpotQA or custom datasets")]
+#[command(version)]
+struct Args {
+    /// Dataset to use: "hotpotqa" or path to a JSON file
+    #[arg(long, short = 'd')]
+    dataset: String,
+
+    /// Number of samples to evaluate (default: all)
+    #[arg(long, short = 's')]
+    sample: Option<usize>,
+
+    /// Comma-separated list of scorers: f1, exact_match, contains
+    #[arg(long, default_value = "f1,exact_match")]
+    scorer: String,
+
+    /// Agent to evaluate: deep_research, react, simple_qa
+    #[arg(long, short = 'a', default_value = "deep_research")]
+    agent: String,
+
+    /// Maximum concurrent evaluations
+    #[arg(long, default_value = "5")]
+    concurrency: usize,
+
+    /// Maximum retry attempts per question
+    #[arg(long, default_value = "1")]
+    retries: usize,
+
+    /// Output format: table or json
+    #[arg(long, short = 'o', default_value = "table")]
+    output: String,
+
+    /// Output file path (defaults to stdout for table, required for json)
+    #[arg(long)]
+    output_file: Option<PathBuf>,
+
+    /// Gemini API key (can also use GEMINI_API_KEY env var)
+    #[arg(long, env = "GEMINI_API_KEY")]
+    api_key: String,
+
+    /// LLM request timeout in seconds
+    #[arg(long, default_value = "60")]
+    llm_timeout: u64,
+
+    /// Maximum tokens per LLM request
+    #[arg(long, default_value = "4096")]
+    max_tokens: u32,
+
+    /// Temperature for LLM generation (0.0-1.0)
+    #[arg(long, default_value_t = 0.7)]
+    temperature: f32,
+
+    /// Enable verbose logging
+    #[arg(short, long)]
+    verbose: bool,
+}
+
+impl Args {
+    /// Validate CLI arguments.
+    fn validate(&self) -> Result<(), String> {
+        // Validate output format
+        if !["table", "json"].contains(&self.output.as_str()) {
+            return Err(format!(
+                "Invalid output format '{}'. Use 'table' or 'json'.",
+                self.output
+            ));
+        }
+
+        // Validate scorers
+        for scorer in self.scorer.split(',') {
+            let scorer = scorer.trim();
+            if !["f1", "exact_match", "contains"].contains(&scorer) {
+                return Err(format!(
+                    "Invalid scorer '{}'. Use f1, exact_match, or contains.",
+                    scorer
+                ));
+            }
+        }
+
+        // Validate agent
+        if !["deep_research", "react", "simple_qa"].contains(&self.agent.as_str()) {
+            return Err(format!(
+                "Invalid agent '{}'. Use deep_research, react, or simple_qa.",
+                self.agent
+            ));
+        }
+
+        // Validate concurrency
+        if self.concurrency == 0 {
+            return Err("concurrency must be greater than 0".to_string());
+        }
+
+        // Validate temperature
+        if !(0.0..=1.0).contains(&self.temperature) {
+            return Err(format!(
+                "temperature ({}) must be between 0.0 and 1.0",
+                self.temperature
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Build LlmConfig from CLI arguments.
+    fn llm_config(&self) -> LlmConfig {
+        LlmConfig {
+            timeout: Duration::from_secs(self.llm_timeout),
+            max_tokens: self.max_tokens,
+            temperature: self.temperature,
+            max_retries: 2,
+            retry_base_delay_ms: 1000,
+        }
+    }
+
+    /// Build EvalConfig from CLI arguments.
+    fn eval_config(&self) -> EvalConfig {
+        EvalConfig::new()
+            .with_concurrency(self.concurrency)
+            .with_max_retries(self.retries)
+    }
+
+    /// Build Scorers from CLI arguments.
+    fn scorers(&self) -> Scorers {
+        let mut scorers = Scorers::new(vec![]);
+        for scorer in self.scorer.split(',') {
+            match scorer.trim() {
+                "f1" => scorers.add(F1Score),
+                "exact_match" => scorers.add(ExactMatch),
+                "contains" => scorers.add(Contains),
+                _ => {} // Already validated
+            }
+        }
+        scorers
+    }
+}
+
+/// Create the agent registry with all available agents.
+fn create_registry() -> AgentRegistry {
+    let mut registry = AgentRegistry::new();
+
+    registry.register("deep_research", || {
+        Box::new(DeepResearchAgent::new(ResearchConfig::default()).unwrap())
+    });
+
+    registry.register("react", || {
+        Box::new(ReactAgent::new(ReactConfig::default()).unwrap())
+    });
+
+    registry.register("simple_qa", || {
+        Box::new(SimpleQaAgent::new(SimpleQaConfig::default()).unwrap())
+    });
+
+    registry
+}
+
+/// Run evaluation with progress display.
+async fn run_evaluation(args: &Args) -> Result<EvalSummary, String> {
+    // Create LLM client
+    let genai_client = rust_genai::Client::builder(args.api_key.clone()).build();
+    let llm = LlmClient::new(genai_client, args.llm_config());
+
+    // Create agent
+    let registry = create_registry();
+    let agent = registry
+        .get(&args.agent)
+        .ok_or_else(|| format!("Agent '{}' not found", args.agent))?;
+
+    // Create harness
+    let harness = EvalHarness::new(args.eval_config());
+    let scorers = args.scorers();
+
+    // Load dataset and run evaluation based on dataset type
+    if args.dataset.to_lowercase() == "hotpotqa" {
+        let dataset = HotpotQA::new().map_err(|e| format!("Failed to create HotpotQA: {}", e))?;
+        run_with_progress(
+            &harness,
+            agent.as_ref(),
+            &dataset,
+            args.sample,
+            scorers,
+            llm,
+        )
+        .await
+    } else {
+        let path = PathBuf::from(&args.dataset);
+        if !path.exists() {
+            return Err(format!("Dataset file not found: {}", args.dataset));
+        }
+        let dataset = JsonFileDataset::new(path);
+        run_with_progress(
+            &harness,
+            agent.as_ref(),
+            &dataset,
+            args.sample,
+            scorers,
+            llm,
+        )
+        .await
+    }
+}
+
+/// Run evaluation with progress bar.
+async fn run_with_progress<D: Dataset>(
+    harness: &EvalHarness,
+    agent: &dyn gemicro_core::Agent,
+    dataset: &D,
+    sample_size: Option<usize>,
+    scorers: Scorers,
+    llm: LlmClient,
+) -> Result<EvalSummary, String> {
+    let progress_bar = ProgressBar::new(0);
+    progress_bar.set_style(
+        ProgressStyle::default_bar()
+            .template("{spinner:.green} [{bar:40.cyan/blue}] {pos}/{len} ({eta}) {msg}")
+            .unwrap()
+            .progress_chars("#>-"),
+    );
+
+    let summary = harness
+        .evaluate_with_progress(agent, dataset, sample_size, scorers, llm, |progress| {
+            match progress {
+                EvalProgress::Started { total } => {
+                    progress_bar.set_length(total as u64);
+                    progress_bar.set_message("Evaluating...");
+                }
+                EvalProgress::QuestionCompleted {
+                    completed, success, ..
+                } => {
+                    progress_bar.set_position(completed as u64);
+                    if !success {
+                        progress_bar.set_message("(some failures)");
+                    }
+                }
+                _ => {} // Handle future variants gracefully
+            }
+        })
+        .await
+        .map_err(|e| format!("Evaluation failed: {}", e))?;
+
+    progress_bar.finish_with_message("Complete");
+    Ok(summary)
+}
+
+/// Output results in the requested format.
+fn output_results(summary: &EvalSummary, args: &Args) -> Result<(), String> {
+    match args.output.as_str() {
+        "table" => {
+            summary.print_summary();
+            if let Some(path) = &args.output_file {
+                summary
+                    .write_json(path)
+                    .map_err(|e| format!("Failed to write output file: {}", e))?;
+                println!("\nDetailed results written to: {}", path.display());
+            }
+        }
+        "json" => {
+            let json = serde_json::to_string_pretty(summary)
+                .map_err(|e| format!("Failed to serialize results: {}", e))?;
+
+            if let Some(path) = &args.output_file {
+                std::fs::write(path, &json)
+                    .map_err(|e| format!("Failed to write output file: {}", e))?;
+                eprintln!("Results written to: {}", path.display());
+            } else {
+                println!("{}", json);
+            }
+        }
+        _ => unreachable!(), // Already validated
+    }
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let args = Args::parse();
+
+    // Initialize logging
+    if args.verbose {
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    } else {
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
+    }
+
+    // Validate arguments
+    if let Err(e) = args.validate() {
+        eprintln!("Error: {}", e);
+        return ExitCode::FAILURE;
+    }
+
+    // Print configuration
+    eprintln!("=== Gemicro Evaluation ===");
+    eprintln!("Dataset: {}", args.dataset);
+    eprintln!("Agent: {}", args.agent);
+    eprintln!("Scorers: {}", args.scorer);
+    eprintln!(
+        "Sample size: {}",
+        args.sample
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "all".to_string())
+    );
+    eprintln!("Concurrency: {}", args.concurrency);
+    eprintln!();
+
+    // Run evaluation
+    match run_evaluation(&args).await {
+        Ok(summary) => {
+            if let Err(e) = output_results(&summary, &args) {
+                eprintln!("Error: {}", e);
+                return ExitCode::FAILURE;
+            }
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_args() -> Args {
+        Args {
+            dataset: "hotpotqa".to_string(),
+            sample: Some(10),
+            scorer: "f1,exact_match".to_string(),
+            agent: "deep_research".to_string(),
+            concurrency: 5,
+            retries: 1,
+            output: "table".to_string(),
+            output_file: None,
+            api_key: "test-key".to_string(),
+            llm_timeout: 60,
+            max_tokens: 4096,
+            temperature: 0.7,
+            verbose: false,
+        }
+    }
+
+    #[test]
+    fn test_validate_valid_args() {
+        let args = test_args();
+        assert!(args.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_invalid_output() {
+        let mut args = test_args();
+        args.output = "invalid".to_string();
+        assert!(args.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_invalid_scorer() {
+        let mut args = test_args();
+        args.scorer = "invalid".to_string();
+        assert!(args.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_invalid_agent() {
+        let mut args = test_args();
+        args.agent = "invalid".to_string();
+        assert!(args.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_zero_concurrency() {
+        let mut args = test_args();
+        args.concurrency = 0;
+        assert!(args.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_invalid_temperature() {
+        let mut args = test_args();
+        args.temperature = 1.5;
+        assert!(args.validate().is_err());
+    }
+
+    #[test]
+    fn test_scorers_parsing() {
+        let mut args = test_args();
+        args.scorer = "f1, exact_match, contains".to_string();
+
+        let scorers = args.scorers();
+        // Scorers are opaque, but we can verify no panic occurred
+        assert!(scorers.score_all("test", "test").len() == 3);
+    }
+
+    #[test]
+    fn test_registry_has_all_agents() {
+        let registry = create_registry();
+        assert!(registry.contains("deep_research"));
+        assert!(registry.contains("react"));
+        assert!(registry.contains("simple_qa"));
+    }
+
+    #[test]
+    fn test_llm_config() {
+        let args = test_args();
+        let config = args.llm_config();
+
+        assert_eq!(config.timeout, Duration::from_secs(60));
+        assert_eq!(config.max_tokens, 4096);
+        assert_eq!(config.temperature, 0.7);
+    }
+
+    #[test]
+    fn test_eval_config() {
+        let args = test_args();
+        let config = args.eval_config();
+
+        assert_eq!(config.concurrency, 5);
+        assert_eq!(config.max_retries, 1);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `gemicro-eval` binary for running evaluations from the command line
- Implements Option B from issue #80 (separate binary in gemicro-eval crate)
- Full feature parity with the library API

## Usage

```bash
# Basic usage with HotpotQA
gemicro-eval --dataset hotpotqa --sample 50

# Custom dataset with specific agent
gemicro-eval --dataset ./questions.json --agent react --scorer f1,contains

# JSON output
gemicro-eval --dataset hotpotqa --sample 10 --output json --output-file results.json

# All options
gemicro-eval \
  --dataset hotpotqa \
  --sample 100 \
  --agent deep_research \
  --scorer f1,exact_match,contains \
  --concurrency 10 \
  --retries 2 \
  --output table \
  --temperature 0.5
```

## Features

| Feature | Description |
|---------|-------------|
| **Datasets** | HotpotQA (auto-downloads), custom JSON files |
| **Agents** | deep_research, react, simple_qa |
| **Scorers** | f1, exact_match, contains (comma-separated) |
| **Output** | table (human-readable), json (machine-readable) |
| **Progress** | Real-time progress bar with indicatif |
| **Config** | Concurrency, retries, timeout, temperature, max_tokens |

## Test plan

- [x] All unit tests pass (10 new tests added)
- [x] All existing tests pass (360+ tests)
- [x] Format check passes
- [x] Clippy passes
- [x] CLI --help works correctly

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)