### PR TITLE
refactor: Remove LlmResponse wrapper, return InteractionResponse directly

### DIFF
--- a/docs/AGENT_AUTHORING.md
+++ b/docs/AGENT_AUTHORING.md
@@ -196,13 +196,17 @@ impl Agent for SimpleQaAgent {
                 || timeout_error(start, config.timeout, "query"),
             ).await?;
 
+            // Extract text and token count from InteractionResponse
+            let answer = response.text().unwrap_or("").to_string();
+            let tokens_used = extract_total_tokens(&response);
+
             // Emit result event
             yield AgentUpdate::custom(
                 EVENT_SIMPLE_QA_RESULT,
-                response.text.clone(),
+                answer.clone(),
                 json!({
-                    "answer": response.text,
-                    "tokens_used": response.tokens_used,
+                    "answer": answer,
+                    "tokens_used": tokens_used,
                     "duration_ms": start.elapsed().as_millis() as u64,
                 }),
             );

--- a/gemicro-core/src/agent/simple_qa.rs
+++ b/gemicro-core/src/agent/simple_qa.rs
@@ -13,7 +13,7 @@ use crate::agent::{Agent, AgentContext, AgentStream};
 use crate::error::AgentError;
 use crate::llm::LlmRequest;
 use crate::update::AgentUpdate;
-use crate::utils::truncate;
+use crate::utils::{extract_total_tokens, truncate};
 
 use async_stream::try_stream;
 use serde_json::json;
@@ -203,8 +203,8 @@ impl Agent for SimpleQaAgent {
             )
             .await?;
 
-            let answer = response.text;
-            let tokens_used = response.tokens_used;
+            let answer = response.text().unwrap_or("").to_string();
+            let tokens_used = extract_total_tokens(&response);
             let duration_ms = start.elapsed().as_millis() as u64;
 
             // Emit agent-specific result event

--- a/gemicro-core/src/lib.rs
+++ b/gemicro-core/src/lib.rs
@@ -54,7 +54,9 @@ pub use config::{
 };
 pub use error::{AgentError, GemicroError, LlmError};
 pub use history::{ConversationHistory, HistoryEntry};
-pub use llm::{LlmClient, LlmRequest, LlmResponse, LlmStreamChunk};
+pub use llm::{LlmClient, LlmRequest, LlmStreamChunk};
+// Re-export rust-genai types for convenience
+pub use rust_genai::{InteractionResponse, UsageMetadata};
 pub use update::{
     AgentUpdate, FinalResult, ResultMetadata, SubQueryResult, EVENT_DECOMPOSITION_COMPLETE,
     EVENT_DECOMPOSITION_STARTED, EVENT_FINAL_RESULT, EVENT_REACT_ACTION, EVENT_REACT_COMPLETE,
@@ -62,4 +64,4 @@ pub use update::{
     EVENT_SUB_QUERY_COMPLETED, EVENT_SUB_QUERY_FAILED, EVENT_SUB_QUERY_STARTED,
     EVENT_SYNTHESIS_STARTED,
 };
-pub use utils::{first_sentence, truncate, truncate_with_count};
+pub use utils::{extract_total_tokens, first_sentence, truncate, truncate_with_count};

--- a/gemicro-core/tests/llm_integration.rs
+++ b/gemicro-core/tests/llm_integration.rs
@@ -23,21 +23,20 @@ async fn test_generate_simple_prompt() {
 
     match response {
         Ok(resp) => {
-            println!("Response: {}", resp.text);
-            println!("Tokens used: {:?}", resp.tokens_used);
-            println!("Interaction ID: {}", resp.interaction_id);
+            let text = resp.text().unwrap_or("");
+            let tokens_used = resp.usage.as_ref().and_then(|u| u.total_tokens);
+            println!("Response: {}", text);
+            println!("Tokens used: {:?}", tokens_used);
+            println!("Interaction ID: {}", resp.id);
 
             // Basic assertions
-            assert!(!resp.text.is_empty(), "Response text should not be empty");
+            assert!(!text.is_empty(), "Response text should not be empty");
             assert!(
-                resp.text.contains('4'),
+                text.contains('4'),
                 "Response should contain '4', got: {}",
-                resp.text
+                text
             );
-            assert!(
-                !resp.interaction_id.is_empty(),
-                "Interaction ID should not be empty"
-            );
+            assert!(!resp.id.is_empty(), "Interaction ID should not be empty");
         }
         Err(e) => {
             panic!("Generate failed: {:?}", e);
@@ -62,14 +61,15 @@ async fn test_generate_with_system_instruction() {
 
     match response {
         Ok(resp) => {
-            println!("Response: {}", resp.text);
+            let text = resp.text().unwrap_or("");
+            println!("Response: {}", text);
 
-            assert!(!resp.text.is_empty(), "Response text should not be empty");
+            assert!(!text.is_empty(), "Response text should not be empty");
             // The response should mention Paris
             assert!(
-                resp.text.to_lowercase().contains("paris"),
+                text.to_lowercase().contains("paris"),
                 "Response should mention Paris, got: {}",
-                resp.text
+                text
             );
         }
         Err(e) => {
@@ -242,22 +242,24 @@ async fn test_google_search_grounding() {
 
     match response {
         Ok(resp) => {
-            println!("Grounded response: {}", resp.text);
-            println!("Tokens used: {:?}", resp.tokens_used);
+            let text = resp.text().unwrap_or("");
+            let tokens_used = resp.usage.as_ref().and_then(|u| u.total_tokens);
+            println!("Grounded response: {}", text);
+            println!("Tokens used: {:?}", tokens_used);
 
             // Basic assertions - response should not be empty
-            assert!(!resp.text.is_empty(), "Response text should not be empty");
+            assert!(!text.is_empty(), "Response text should not be empty");
 
             // The grounded response should contain date-related content
             // (we can't check for exact date since it may vary)
             assert!(
-                resp.text.to_lowercase().contains("2024")
-                    || resp.text.to_lowercase().contains("2025")
-                    || resp.text.to_lowercase().contains("december")
-                    || resp.text.to_lowercase().contains("january")
-                    || resp.text.to_lowercase().contains("today"),
+                text.to_lowercase().contains("2024")
+                    || text.to_lowercase().contains("2025")
+                    || text.to_lowercase().contains("december")
+                    || text.to_lowercase().contains("january")
+                    || text.to_lowercase().contains("today"),
                 "Grounded response should contain date-related content, got: {}",
-                resp.text
+                text
             );
         }
         Err(e) => {
@@ -298,14 +300,15 @@ async fn test_structured_output_response_format() {
 
     match response {
         Ok(resp) => {
-            println!("Structured response: {}", resp.text);
+            let text = resp.text().unwrap_or("");
+            println!("Structured response: {}", text);
 
             // Parse the response as JSON
-            let parsed: Result<serde_json::Value, _> = serde_json::from_str(&resp.text);
+            let parsed: Result<serde_json::Value, _> = serde_json::from_str(text);
             assert!(
                 parsed.is_ok(),
                 "Response should be valid JSON, got: {}",
-                resp.text
+                text
             );
 
             let json = parsed.unwrap();


### PR DESCRIPTION
## Summary

Removes the lossy `LlmResponse` wrapper and returns `rust_genai::InteractionResponse` directly from `LlmClient`. This gives agents access to full response data instead of just text and total tokens.

### Motivation

The `LlmResponse` wrapper was hiding useful data from rust-genai:

| What rust-genai provides | What LlmResponse kept |
|--------------------------|----------------------|
| `UsageMetadata` (input, output, cached, reasoning tokens) | Just `total_tokens` as `u32` |
| `grounding_metadata` (search results, citations) | Nothing |
| `function_calls` | Nothing |
| Rich `InteractionContent` | Just `.text()` |

### Changes

**Deleted (~220 lines)**
- `LlmResponse` struct
- `extract_token_count()` method
- `parse_json_array()` function and 16 unit tests

**Added (~75 lines)**
- `extract_total_tokens()` helper in utils.rs with overflow protection
- `response_format` schema for decomposition (guarantees valid JSON)
- Re-exports for `InteractionResponse` and `UsageMetadata`

**Updated**
- All agents now use `response.text()` and `extract_total_tokens(&response)`
- Integration tests updated for new API
- Documentation updated with new patterns

### Benefits

1. **No lossy conversion** - agents get full `UsageMetadata`
2. **Eliminates JSON parsing fragility** - `response_format` guarantees valid JSON
3. **Centralized token extraction** - consistent handling across all agents
4. **Net reduction** - removes ~145 lines of code

## Test plan

- [x] All 162 tests pass (`cargo test --workspace`)
- [x] Clippy clean (`cargo clippy --workspace -- -D warnings`)
- [x] Build succeeds (`cargo build --workspace`)

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)