### PR TITLE
chore: Add Makefile with quality gate commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,36 +13,33 @@ Gemicro is a CLI agent exploration platform for experimenting with AI agent impl
 ## Build Commands
 
 ```bash
-# Build entire workspace
-cargo build --workspace
+# Run all quality gates before pushing (format, clippy, tests)
+make check
 
-# Run tests (unit + doc tests)
-cargo test --workspace
+# Individual commands
+make fmt        # Check formatting
+make clippy     # Run clippy with -D warnings
+make test       # Run unit + doc tests
+make test-all   # Include LLM integration tests (requires GEMINI_API_KEY)
+make docs       # Build documentation
+make clean      # Clean build artifacts
+```
 
-# Run ALL tests including LLM integration tests (requires GEMINI_API_KEY)
-cargo test --workspace -- --include-ignored
+### Direct Cargo Commands
 
+```bash
 # Run a single test
 cargo test test_name
 
 # Run tests in a specific module
 cargo test agent::tests
 
-# Linting
-cargo clippy --workspace -- -D warnings
-
-# Format check
-cargo fmt --all -- --check
-
-# Build docs
-cargo doc --workspace --no-deps
-
-# Run the deep research example
-cargo run -p gemicro-deep-research --example deep_research
-
 # Run specific crate tests
 cargo test -p gemicro-runner
 cargo test -p gemicro-eval
+
+# Run the deep research example
+cargo run -p gemicro-deep-research --example deep_research
 ```
 
 ## Environment Setup

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+.PHONY: check fmt clippy test test-all docs clean
+
+# Run all quality gates (format check, clippy, tests)
+check: fmt clippy test
+
+# Check formatting
+fmt:
+	cargo fmt --all -- --check
+
+# Run clippy with warnings as errors
+clippy:
+	cargo clippy --workspace -- -D warnings
+
+# Run unit and doc tests
+test:
+	cargo test --workspace
+
+# Run all tests including LLM integration tests (requires GEMINI_API_KEY)
+test-all:
+	cargo test --workspace -- --include-ignored
+
+# Build documentation
+docs:
+	cargo doc --workspace --no-deps
+
+# Clean build artifacts
+clean:
+	cargo clean

--- a/README.md
+++ b/README.md
@@ -184,17 +184,14 @@ cargo build --workspace
 # Build workspace
 cargo build --workspace
 
-# Run unit tests
-cargo test --workspace
+# Run all quality gates (format, clippy, tests)
+make check
 
-# Run ALL tests including LLM integration tests
-cargo test --workspace -- --include-ignored
-
-# Linting
-cargo clippy --workspace -- -D warnings
-
-# Format check
-cargo fmt --all -- --check
+# Individual quality gates
+make fmt        # Check formatting
+make clippy     # Run clippy with -D warnings
+make test       # Run unit + doc tests
+make test-all   # Include LLM integration tests (requires GEMINI_API_KEY)
 ```
 
 ### Running Examples


### PR DESCRIPTION
## Summary

- Add `Makefile` with quality gate targets for streamlined development workflow
- Update CLAUDE.md and README.md to reference new make targets

## Make Targets

| Target | Description |
|--------|-------------|
| `make check` | Run all quality gates (fmt, clippy, test) |
| `make fmt` | Check formatting |
| `make clippy` | Run clippy with -D warnings |
| `make test` | Run unit + doc tests |
| `make test-all` | Include LLM integration tests |
| `make docs` | Build documentation |
| `make clean` | Clean build artifacts |

## Test plan

- [x] `make check` passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)