### PR TITLE
docs: Update crate count to reflect current workspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Gemicro is a CLI agent exploration platform for experimenting with AI agent implementation patterns, powered by the Gemini API via the rust-genai library.
 
-**Key Architecture**: 13-crate workspace with layered dependencies (5 agent crates in `agents/`, 4 tool crates in `tools/`)
+**Key Architecture**: 18-crate workspace with layered dependencies (5 agent crates in `agents/`, 9 tool crates in `tools/`)
 
 **Current Status**: Core implementation complete. Remaining work tracked in [GitHub Issues](https://github.com/evansenter/gemicro/issues).
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ Gemicro allows you to explore and interact with different AI agent patterns thro
 
 ## Architecture
 
-### Nine-Crate Workspace
+### 18-Crate Workspace
 
 ```
-gemicro-core (Agent trait, events, LLM - GENERIC ONLY)
+gemicro-core (Agent trait, Tool trait, events, LLM - GENERIC ONLY)
     ↓
+tools/* (one crate per tool - file_read, web_fetch, bash, etc.)
 agents/* (one crate per agent - hermetic isolation)
     ↓
 gemicro-runner (execution state, metrics, runner)


### PR DESCRIPTION
## Summary

Updates documentation to reflect the current 18-crate workspace structure.

- **CLAUDE.md**: "13-crate workspace" → "18-crate workspace", "4 tool crates" → "9 tool crates"
- **README.md**: "Nine-Crate Workspace" → "18-Crate Workspace", added tools layer to architecture diagram

The workspace grew from 13 to 18 crates with the addition of 5 new tool crates:
- gemicro-glob
- gemicro-grep
- gemicro-file-write
- gemicro-file-edit
- gemicro-bash

🤖 Generated with [Claude Code](https://claude.com/claude-code)