### PR TITLE
test: Add integration tests for LlmJudgeScorer

### DIFF
--- a/gemicro-eval/tests/scorer_integration.rs
+++ b/gemicro-eval/tests/scorer_integration.rs
@@ -17,7 +17,7 @@ fn create_test_scorer(api_key: &str) -> LlmJudgeScorer {
     let config = LlmConfig::default()
         .with_timeout(Duration::from_secs(30))
         .with_max_tokens(1024)
-        .with_temperature(0.7)
+        .with_temperature(0.0)
         .with_max_retries(1)
         .with_retry_base_delay_ms(500);
     let llm = Arc::new(LlmClient::new(genai_client, config));
@@ -116,6 +116,50 @@ async fn test_llm_judge_scorer_semantic_equivalence() {
     assert!(
         (score - 1.0).abs() < f64::EPSILON,
         "Semantically equivalent answers should return 1.0, got: {score}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore] // Requires GEMINI_API_KEY
+async fn test_llm_judge_scorer_empty_strings() {
+    let Some(api_key) = get_api_key() else {
+        eprintln!("Skipping test: GEMINI_API_KEY not set");
+        return;
+    };
+
+    let scorer = create_test_scorer(&api_key);
+
+    // Empty predicted against non-empty ground truth should be incorrect
+    let score = scorer.score("", "Paris");
+
+    // Should return a valid score (not NaN) even for edge cases
+    assert!(
+        !score.is_nan(),
+        "Scorer should handle empty strings gracefully"
+    );
+    assert!(
+        score.abs() < f64::EPSILON,
+        "Empty answer should return 0.0, got: {score}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore] // Requires GEMINI_API_KEY
+async fn test_llm_judge_scorer_numeric_answer() {
+    let Some(api_key) = get_api_key() else {
+        eprintln!("Skipping test: GEMINI_API_KEY not set");
+        return;
+    };
+
+    let scorer = create_test_scorer(&api_key);
+
+    // Numeric answers should be compared correctly
+    let score = scorer.score("42", "42");
+
+    assert!(!score.is_nan(), "Scorer should handle numeric answers");
+    assert!(
+        (score - 1.0).abs() < f64::EPSILON,
+        "Matching numeric answer should return 1.0, got: {score}"
     );
 }
 


### PR DESCRIPTION
## Summary

Adds integration tests for `LlmJudgeScorer` in `gemicro-eval`, addressing the acceptance criteria from issue #99.

## Changes

New file: `gemicro-eval/tests/scorer_integration.rs` with 7 tests:
- `test_llm_judge_scorer_correct_answer` - Verifies exact match returns 1.0
- `test_llm_judge_scorer_incorrect_answer` - Verifies wrong answer returns 0.0
- `test_llm_judge_scorer_semantic_match` - Verifies semantic match returns 1.0
- `test_llm_judge_scorer_semantic_equivalence` - Verifies differently-worded equivalents
- `test_llm_judge_scorer_empty_strings` - Verifies empty input handling
- `test_llm_judge_scorer_numeric_answer` - Verifies numeric answer comparison
- `test_llm_judge_scorer_name` - Unit test for scorer name (no API key needed)

Uses `temperature: 0.0` for deterministic test results.

## Test Plan

- [x] All integration tests marked with `#[ignore]` (require API key)
- [x] Tests run successfully with `cargo test -p gemicro-eval -- --include-ignored`
- [x] `make check` passes (fmt, clippy, tests)

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)