### PR TITLE
feat: Use centralized claude-review prompt from dotfiles

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,26 +3,18 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+
+env:
+  # Centralized prompt - edit in dotfiles repo, all repos pick up changes
+  PROMPT_URL: https://raw.githubusercontent.com/evansenter/dotfiles/main/home/.claude/contrib/prompts/claude-review.md
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write  # Needed to post comments
+      issues: write         # Read linked issues, optionally comment if PR incomplete
       id-token: write
 
     steps:
@@ -31,6 +23,21 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Fetch review prompt
+        id: prompt
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if curl -sfL "$PROMPT_URL" > /tmp/review-prompt.md && [ -s /tmp/review-prompt.md ]; then
+            echo "Fetched review prompt ($(wc -l < /tmp/review-prompt.md) lines)"
+            echo "use_file=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Failed to fetch centralized prompt from $PROMPT_URL - using fallback"
+            echo "use_file=false" >> "$GITHUB_OUTPUT"
+            # Post warning comment on PR
+            gh pr comment ${{ github.event.pull_request.number }} --body "⚠️ **Claude Review Warning**: Could not fetch centralized review prompt from \`$PROMPT_URL\`. Using fallback inline prompt. This may result in less thorough reviews."
+          fi
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
@@ -38,19 +45,10 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR_NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
+            ${{ steps.prompt.outputs.use_file == 'true' && 'First, read the review instructions from /tmp/review-prompt.md using your Read tool. Then follow those instructions to review this PR.' || 'Review this PR for code quality, bugs, security issues, and adherence to project conventions (check CLAUDE.md). Check for previous "Feedback Addressed" comments to avoid re-raising resolved issues. Be strict: REQUEST_CHANGES for any issues found, only APPROVE if genuinely ready to merge. Post your review using gh pr comment. Start your comment with: > **Prompt:** Fallback (centralized prompt fetch failed)' }}
 
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
-
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
-
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--model opus --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+            Use the REPO and PR_NUMBER variables provided above.
+          # Tools required by the centralized prompt (see contrib/prompts/claude-review.md)
+          claude_args: '--model opus --allowed-tools "Read,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh api:*)"'


### PR DESCRIPTION
## Summary

Switches from inline prompt to centralized prompt hosted in dotfiles repo.

## Benefits

- Consistent review standards across all repos
- Single source of truth for review criteria
- Automatic "Feedback Addressed" detection to avoid re-raising resolved issues
- Linked issue checking for context
- Prompt source shown in reviews for transparency

## Changes

- Fetches prompt from `evansenter/dotfiles/home/.claude/contrib/prompts/claude-review.md`
- Falls back to inline prompt if fetch fails (with warning comment)
- Updated permissions for posting comments and reading issues
- Updated allowed tools to match centralized prompt requirements

## Related

Closes evansenter/dotfiles#87

🤖 Generated with [Claude Code](https://claude.com/claude-code)