### PR TITLE
feat(core): Change FinalResult.answer to FinalResult.result: Value

### DIFF
--- a/agents/gemicro-deep-research/examples/deep_research.rs
+++ b/agents/gemicro-deep-research/examples/deep_research.rs
@@ -253,6 +253,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "final_result" => {
                     if let Some(result) = update.as_final_result() {
                         let total_duration = overall_start.elapsed();
+                        let answer = result.result.as_str().unwrap_or("");
 
                         println!();
                         println!(
@@ -265,7 +266,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             "╚══════════════════════════════════════════════════════════════╝"
                         );
                         println!();
-                        println!("{}", result.answer);
+                        println!("{}", answer);
                         println!();
                         println!("══════════════════════════════════════════════════════════════");
 

--- a/agents/gemicro-deep-research/src/agent.rs
+++ b/agents/gemicro-deep-research/src/agent.rs
@@ -198,7 +198,7 @@ impl DeepResearchAgent {
                 }),
             );
 
-            yield AgentUpdate::final_result(answer, metadata);
+            yield AgentUpdate::final_result(json!(answer), metadata);
         }
     }
 }

--- a/agents/gemicro-deep-research/tests/integration.rs
+++ b/agents/gemicro-deep-research/tests/integration.rs
@@ -70,9 +70,10 @@ async fn test_deep_research_agent_full_flow() {
                     }
                     "final_result" => {
                         if let Some(result) = update.as_final_result() {
-                            final_answer = result.answer.clone();
+                            let answer = result.result.as_str().unwrap_or("");
+                            final_answer = answer.to_string();
                             println!("\n=== Final Answer ===");
-                            println!("{}", result.answer);
+                            println!("{}", answer);
                             println!("\n=== Metadata ===");
                             println!("  Total tokens: {}", result.metadata.total_tokens);
                             println!(

--- a/agents/gemicro-react/src/agent.rs
+++ b/agents/gemicro-react/src/agent.rs
@@ -196,7 +196,7 @@ impl ReactAgent {
                         tokens_unavailable,
                         start_time.elapsed().as_millis() as u64,
                     );
-                    yield AgentUpdate::final_result(step.action.input, metadata);
+                    yield AgentUpdate::final_result(json!(step.action.input), metadata);
                     return;
                 }
 
@@ -275,7 +275,7 @@ impl ReactAgent {
                 "Unable to find answer after {} iterations. Last thought: {}",
                 config.max_iterations, last_thought
             );
-            yield AgentUpdate::final_result(fallback_answer, metadata);
+            yield AgentUpdate::final_result(json!(fallback_answer), metadata);
         }
     }
 

--- a/agents/gemicro-simple-qa/src/lib.rs
+++ b/agents/gemicro-simple-qa/src/lib.rs
@@ -262,7 +262,7 @@ impl Agent for SimpleQaAgent {
                 if tokens_used.is_none() { 1 } else { 0 },
                 duration_ms,
             );
-            yield AgentUpdate::final_result(answer, metadata);
+            yield AgentUpdate::final_result(json!(answer), metadata);
         })
     }
 

--- a/agents/gemicro-tool-agent/src/lib.rs
+++ b/agents/gemicro-tool-agent/src/lib.rs
@@ -335,7 +335,7 @@ impl ToolAgent {
                 tokens_unavailable,
                 start_time.elapsed().as_millis() as u64,
             );
-            yield AgentUpdate::final_result(answer, metadata);
+            yield AgentUpdate::final_result(json!(answer), metadata);
         }
     }
 }

--- a/agents/gemicro-tool-agent/tests/integration.rs
+++ b/agents/gemicro-tool-agent/tests/integration.rs
@@ -50,7 +50,7 @@ async fn test_tool_agent_calculator() {
 
                 if update.event_type == "final_result" {
                     if let Some(result) = update.as_final_result() {
-                        final_answer = result.answer.clone();
+                        final_answer = result.result.as_str().unwrap_or("").to_string();
                     }
                 }
             }
@@ -161,7 +161,7 @@ async fn test_tool_agent_complex_math() {
                 println!("[{}] {}", update.event_type, update.message);
                 if update.event_type == "final_result" {
                     if let Some(result) = update.as_final_result() {
-                        final_answer = result.answer.clone();
+                        final_answer = result.result.as_str().unwrap_or("").to_string();
                     }
                 }
             }
@@ -209,7 +209,7 @@ async fn test_tool_agent_current_datetime() {
                 println!("[{}] {}", update.event_type, update.message);
                 if update.event_type == "final_result" {
                     if let Some(result) = update.as_final_result() {
-                        final_answer = result.answer.clone();
+                        final_answer = result.result.as_str().unwrap_or("").to_string();
                     }
                 }
             }
@@ -252,7 +252,7 @@ async fn test_tool_agent_multiple_tools() {
                 println!("[{}] {}", update.event_type, update.message);
                 if update.event_type == "final_result" {
                     if let Some(result) = update.as_final_result() {
-                        final_answer = result.answer.clone();
+                        final_answer = result.result.as_str().unwrap_or("").to_string();
                     }
                 }
             }

--- a/gemicro-cli/src/repl/session.rs
+++ b/gemicro-cli/src/repl/session.rs
@@ -503,7 +503,7 @@ mod tests {
 
                 // Emit final result
                 yield Ok(AgentUpdate::final_result(
-                    "Mock answer".to_string(),
+                    json!("Mock answer"),
                     ResultMetadata::new(100, 0, 50),
                 ));
             })
@@ -591,7 +591,7 @@ mod tests {
 
                 // Emit final result
                 yield Ok(AgentUpdate::final_result(
-                    "Mock answer".to_string(),
+                    json!("Mock answer"),
                     ResultMetadata::new(100, 0, 50),
                 ));
             })
@@ -701,7 +701,7 @@ mod tests {
         let events = vec![
             AgentUpdate::custom("decomposition_started", "Decomposing query", json!({})),
             AgentUpdate::final_result(
-                "The answer".to_string(),
+                json!("The answer"),
                 ResultMetadata::with_extra(
                     1500,
                     0,

--- a/gemicro-core/src/agent/mod.rs
+++ b/gemicro-core/src/agent/mod.rs
@@ -557,7 +557,7 @@ mod tests {
             Ok(AgentUpdate::custom("step_1", "Step 1", json!({}))),
             Ok(AgentUpdate::custom("step_2", "Step 2", json!({}))),
             Ok(AgentUpdate::final_result(
-                "Answer".to_string(),
+                json!("Answer"),
                 ResultMetadata::new(100, 0, 1000),
             )),
         ];
@@ -583,7 +583,7 @@ mod tests {
         let events = vec![
             Ok(AgentUpdate::custom("step_1", "Step 1", json!({}))),
             Ok(AgentUpdate::final_result(
-                "Answer".to_string(),
+                json!("Answer"),
                 ResultMetadata::new(100, 0, 1000),
             )),
             // This violates the contract - events after final_result
@@ -650,7 +650,7 @@ mod tests {
     #[tokio::test]
     async fn test_contract_only_final_result() {
         let events = vec![Ok(AgentUpdate::final_result(
-            "Direct answer".to_string(),
+            json!("Direct answer"),
             ResultMetadata::new(50, 0, 500),
         ))];
 
@@ -679,17 +679,17 @@ mod tests {
         let events = vec![
             Ok(AgentUpdate::custom("step_1", "Step 1", json!({}))),
             Ok(AgentUpdate::final_result(
-                "First answer".to_string(),
+                json!("First answer"),
                 ResultMetadata::new(100, 0, 1000),
             )),
             // Second final_result - violates contract
             Ok(AgentUpdate::final_result(
-                "Second answer".to_string(),
+                json!("Second answer"),
                 ResultMetadata::new(50, 0, 500),
             )),
             // Third final_result - also violates contract
             Ok(AgentUpdate::final_result(
-                "Third answer".to_string(),
+                json!("Third answer"),
                 ResultMetadata::new(25, 0, 250),
             )),
         ];

--- a/gemicro-core/src/history.rs
+++ b/gemicro-core/src/history.rs
@@ -44,12 +44,15 @@ impl HistoryEntry {
         }
     }
 
-    /// Get the final result text, if available
+    /// Get the final result text, if available.
+    ///
+    /// Returns the result as a string if the result is a string value.
+    /// For structured or null results, returns `None`.
     pub fn final_result(&self) -> Option<&str> {
         self.events
             .iter()
             .find(|e| e.event_type == crate::agent::EVENT_FINAL_RESULT)
-            .and_then(|e| e.data.get("answer"))
+            .and_then(|e| e.data.get("result"))
             .and_then(|v| v.as_str())
     }
 }
@@ -169,10 +172,7 @@ mod tests {
                 "Decomposed into 2 sub-queries",
                 json!({ "sub_queries": ["Q1", "Q2"] }),
             ),
-            AgentUpdate::final_result(
-                "The answer is 42".to_string(),
-                ResultMetadata::new(100, 0, 1000),
-            ),
+            AgentUpdate::final_result(json!("The answer is 42"), ResultMetadata::new(100, 0, 1000)),
         ]
     }
 

--- a/gemicro-core/src/tracking.rs
+++ b/gemicro-core/src/tracking.rs
@@ -29,7 +29,7 @@
 //!     }
 //!
 //!     if let Some(result) = tracker.final_result() {
-//!         println!("Answer: {}", result.answer);
+//!         println!("Result: {:?}", result.result);
 //!     }
 //! }
 //! ```
@@ -162,12 +162,12 @@ mod tests {
                 "steps_failed": 1,
             }),
         );
-        let event = AgentUpdate::final_result("The answer is 42".to_string(), metadata);
+        let event = AgentUpdate::final_result(json!("The answer is 42"), metadata);
         tracker.handle_event(&event);
 
         assert!(tracker.is_complete());
         let result = tracker.final_result().unwrap();
-        assert_eq!(result.answer, "The answer is 42");
+        assert_eq!(result.result, json!("The answer is 42"));
         assert_eq!(result.metadata.total_tokens, 100);
         assert_eq!(result.metadata.duration_ms, 5000);
         assert_eq!(result.metadata.extra["steps_succeeded"], 3);

--- a/gemicro-eval/tests/harness_integration.rs
+++ b/gemicro-eval/tests/harness_integration.rs
@@ -9,6 +9,7 @@ use gemicro_core::{
 use gemicro_eval::{
     Dataset, DatasetError, EvalConfig, EvalHarness, EvalProgress, EvalQuestion, Scorers,
 };
+use serde_json::json;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -62,7 +63,7 @@ impl Agent for MockAgent {
                 Err(AgentError::Llm(LlmError::Other("Mock failure".to_string())))?;
             } else {
                 yield AgentUpdate::final_result(
-                    "Mock answer".to_string(),
+                    json!("Mock answer"),
                     ResultMetadata::new(0, 0, 0),
                 );
             }

--- a/gemicro-runner/src/runner.rs
+++ b/gemicro-runner/src/runner.rs
@@ -209,7 +209,7 @@ impl AgentRunner {
                 steps,
                 events,
                 total_duration.as_millis() as u64,
-                metrics.final_answer.clone(),
+                metrics.final_answer.clone().map(serde_json::Value::String),
             );
 
         Ok((metrics, trajectory))
@@ -295,7 +295,7 @@ mod tests {
                 json!({ "id": 0, "result": "Result", "tokens_used": 50 }),
             ),
             AgentUpdate::custom("synthesis_started", "Synthesizing results", json!({})),
-            AgentUpdate::final_result("Final answer".to_string(), metadata),
+            AgentUpdate::final_result(json!("Final answer"), metadata),
         ]
     }
 


### PR DESCRIPTION
## Summary

Implements the recommendation from RFC #160 to change `FinalResult.answer: String` to `FinalResult.result: serde_json::Value`.

This aligns `FinalResult` with the Evergreen soft-typing philosophy used throughout the codebase (e.g., `AgentUpdate.data: Value`, `ResultMetadata.extra: Value`).

### Key Changes

- **Core type change**: `FinalResult.answer: String` → `FinalResult.result: Value`
- **Constructor signature**: `final_result(answer: String, ...)` → `final_result(result: Value, ...)`
- **Trajectory metadata**: `TrajectoryMetadata.final_answer` → `final_result: Option<Value>`

### Usage

```rust
// String result (Q&A agents)
yield AgentUpdate::final_result(json!("The answer"), metadata);

// Structured result
yield AgentUpdate::final_result(json!({"summary": "...", "sources": [...]}), metadata);

// No result (side-effect agents)
yield AgentUpdate::final_result(Value::Null, metadata);
```

### Files Changed (20)

| Layer | Files |
|-------|-------|
| gemicro-core | `update.rs`, `history.rs`, `tracking.rs`, `agent/mod.rs`, `trajectory/data.rs`, `trajectory/builder.rs` |
| gemicro-runner | `metrics.rs`, `runner.rs` |
| gemicro-cli | `format.rs`, `repl/session.rs` |
| agents | All 4 agent crates + examples + integration tests |
| tools | `gemicro-task` |
| gemicro-eval | `dataset.rs`, `harness_integration.rs` |

## Test plan

- [x] `make check` passes (fmt, clippy, all tests)
- [x] All 20 files updated consistently
- [x] Breaking change is intentional per versioning philosophy

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)