### PR TITLE
feat(core): Simplify LlmClient using rust-genai DX improvements

### DIFF
--- a/gemicro-core/src/llm/client.rs
+++ b/gemicro-core/src/llm/client.rs
@@ -357,11 +357,11 @@ impl LlmClient {
         let started_at = SystemTime::now();
         let start_instant = Instant::now();
 
-        // Execute with timeout
-        let timeout_duration = self.config.timeout;
-        let response = tokio::time::timeout(timeout_duration, interaction.create())
+        // Execute with timeout (rust-genai handles timeout natively)
+        let response = interaction
+            .with_timeout(self.config.timeout)
+            .create()
             .await
-            .map_err(|_| LlmError::Timeout(timeout_duration.as_millis() as u64))?
             .map_err(LlmError::from)?;
 
         // Validate response has content

--- a/gemicro-core/src/utils.rs
+++ b/gemicro-core/src/utils.rs
@@ -7,9 +7,8 @@ use rust_genai::InteractionResponse;
 
 /// Extract total token count from an LLM response.
 ///
-/// Safely converts from `i32` to `u32`, returning `None` on negative values
-/// or if usage metadata is unavailable. This centralizes the token extraction
-/// pattern used across all agents.
+/// This is a convenience wrapper around [`InteractionResponse::total_tokens()`]
+/// that converts `i32` to `u32`, returning `None` on negative values.
 ///
 /// # Example
 ///
@@ -28,11 +27,8 @@ use rust_genai::InteractionResponse;
 /// # }
 /// ```
 pub fn extract_total_tokens(response: &InteractionResponse) -> Option<u32> {
-    response
-        .usage
-        .as_ref()
-        .and_then(|u| u.total_tokens)
-        .and_then(|t| u32::try_from(t).ok())
+    // Delegate to rust-genai's native method, converting i32 -> u32
+    response.total_tokens().and_then(|t| u32::try_from(t).ok())
 }
 
 /// Truncate text to a maximum character count, adding ellipsis if needed.


### PR DESCRIPTION
## Summary

Leverages new rust-genai DX features from PR #240 to simplify LlmClient:

- **Native timeout**: Use `.with_timeout()` instead of manual `tokio::time::timeout` wrapping
- **Error mapping**: Custom `From<GenaiError>` impl maps `GenaiError::Timeout(Duration)` to `LlmError::Timeout(u64)` for consistent API
- **Token extraction**: Delegate `extract_total_tokens()` to native `.total_tokens()` method

### Changes

| File | Change |
|------|--------|
| `error.rs` | Custom `From` impl for timeout error mapping + tests |
| `client.rs` | Use `.with_timeout()` instead of manual timeout |
| `utils.rs` | Delegate to `.total_tokens()` |

### Notes

- Streaming still uses `tokio::time::timeout` for per-chunk timeouts (intentional - rust-genai's timeout applies to the full stream)
- All 178+ tests pass

Closes #174

## Test plan

- [x] `make check` passes (fmt, clippy, tests)
- [x] Error mapping tests verify `GenaiError::Timeout` → `LlmError::Timeout`
- [x] Other `GenaiError` variants still map to `LlmError::GenAi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)