### PR TITLE
refactor(core): Remove unused ExternalEvent from interceptor module

### DIFF
--- a/gemicro-core/src/interceptor/mod.rs
+++ b/gemicro-core/src/interceptor/mod.rs
@@ -16,7 +16,6 @@
 //! Common interceptor specializations:
 //! - [`ToolInterceptor`] - Intercepts tool calls (replaces the old `ToolHook` trait)
 //! - [`MessageInterceptor`] - Intercepts user messages
-//! - [`EventInterceptor`] - Intercepts external events (for cross-agent coordination)
 //!
 //! # Example
 //!
@@ -50,7 +49,7 @@
 
 mod types;
 
-pub use types::{ExternalEvent, ToolCall, UserContent, UserMessage};
+pub use types::{ToolCall, UserContent, UserMessage};
 
 use async_trait::async_trait;
 use std::fmt;
@@ -374,9 +373,6 @@ pub type ToolInterceptor = dyn Interceptor<ToolCall, ToolResult>;
 
 /// Message interceptor - intercepts user messages.
 pub type MessageInterceptor = dyn Interceptor<UserMessage, ()>;
-
-/// Event interceptor - intercepts external events (for cross-agent coordination).
-pub type EventInterceptor = dyn Interceptor<ExternalEvent, crate::AgentUpdate>;
 
 // ============================================================================
 // Tests

--- a/gemicro-core/src/interceptor/types.rs
+++ b/gemicro-core/src/interceptor/types.rs
@@ -122,71 +122,6 @@ pub enum UserContent {
 }
 
 // ============================================================================
-// ExternalEvent
-// ============================================================================
-
-/// External event from event bus (for cross-agent coordination).
-///
-/// Used with [`EventInterceptor`](super::EventInterceptor) to filter, transform,
-/// or deny events from external sources before they're processed by an agent.
-///
-/// # Example
-///
-/// ```
-/// use gemicro_core::interceptor::ExternalEvent;
-///
-/// let event = ExternalEvent::new(
-///     42,
-///     "task_completed",
-///     "Task X finished successfully",
-///     "repo:gemicro",
-/// );
-/// assert_eq!(event.event_type, "task_completed");
-/// ```
-#[derive(Debug, Clone, PartialEq)]
-#[non_exhaustive]
-pub struct ExternalEvent {
-    /// Unique event ID from the event bus.
-    pub id: u64,
-
-    /// Type of event (e.g., "task_completed", "help_needed").
-    pub event_type: String,
-
-    /// Event payload/message.
-    pub payload: String,
-
-    /// Channel the event was received on.
-    pub channel: String,
-
-    /// Source session that published the event, if known.
-    pub source_session: Option<String>,
-}
-
-impl ExternalEvent {
-    /// Create a new external event.
-    pub fn new(
-        id: u64,
-        event_type: impl Into<String>,
-        payload: impl Into<String>,
-        channel: impl Into<String>,
-    ) -> Self {
-        Self {
-            id,
-            event_type: event_type.into(),
-            payload: payload.into(),
-            channel: channel.into(),
-            source_session: None,
-        }
-    }
-
-    /// Set the source session.
-    pub fn with_source_session(mut self, session: impl Into<String>) -> Self {
-        self.source_session = Some(session.into());
-        self
-    }
-}
-
-// ============================================================================
 // Tests
 // ============================================================================
 
@@ -235,22 +170,5 @@ mod tests {
 
         assert_eq!(msg1, msg2);
         assert_ne!(msg1, msg3);
-    }
-
-    #[test]
-    fn test_external_event_new() {
-        let event = ExternalEvent::new(1, "test_event", "payload", "channel:test");
-        assert_eq!(event.id, 1);
-        assert_eq!(event.event_type, "test_event");
-        assert_eq!(event.payload, "payload");
-        assert_eq!(event.channel, "channel:test");
-        assert_eq!(event.source_session, None);
-    }
-
-    #[test]
-    fn test_external_event_with_source() {
-        let event =
-            ExternalEvent::new(1, "test", "payload", "channel").with_source_session("session-123");
-        assert_eq!(event.source_session, Some("session-123".to_string()));
     }
 }


### PR DESCRIPTION
## Summary

- Remove unused `ExternalEvent` struct from `interceptor/types.rs`
- Remove unused `EventInterceptor` type alias from `interceptor/mod.rs`
- Update module doc comments

## Context

The interceptor module had its own `ExternalEvent` type that was never used:
- `EventInterceptor` type alias existed only in docs, never instantiated
- `ExternalEvent` duplicated `coordination::ExternalEvent` with different field types (`id: u64` vs `id: i64`, missing `timestamp`)

The canonical `ExternalEvent` type lives in `gemicro_core::coordination` and is used by `HubCoordination` for SSE event delivery.

## Test plan

- [x] `make check` passes (fmt, clippy, tests)
- [x] Grep confirms no remaining usages of interceptor's `ExternalEvent`
- [x] All 500+ tests pass

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)