### PR TITLE
feat(core): Add ergonomic type accessors for FinalResult and AgentError (#202)

### DIFF
--- a/agents/gemicro-critique/src/lib.rs
+++ b/agents/gemicro-critique/src/lib.rs
@@ -792,13 +792,13 @@ impl CritiqueAgent {
             // Skip intermediate events; wait for final_result which contains full CritiqueOutput
             // Use as_final_result() for type-safe access to the result field
             if let Some(final_result) = update.as_final_result() {
-                let output: CritiqueOutput =
-                    serde_json::from_value(final_result.result).map_err(|e| {
-                        AgentError::ParseFailed(format!(
-                            "Failed to parse CritiqueOutput from final_result: {}",
-                            e
-                        ))
-                    })?;
+                // Use result_as<T>() for ergonomic typed deserialization
+                let output = final_result.result_as::<CritiqueOutput>().map_err(|e| {
+                    AgentError::ParseFailed(format!(
+                        "Failed to parse CritiqueOutput from final_result: {}",
+                        e
+                    ))
+                })?;
                 return Ok(output);
             }
         }

--- a/agents/gemicro-tool-agent/tests/integration.rs
+++ b/agents/gemicro-tool-agent/tests/integration.rs
@@ -48,7 +48,7 @@ async fn test_tool_agent_calculator() {
                     tool_complete_data = Some(update.data.clone());
                 }
 
-                if update.event_type == "final_result" {
+                if update.is_final_result() {
                     if let Some(result) = update.as_final_result() {
                         final_answer = result.result.as_str().unwrap_or("").to_string();
                     }
@@ -159,7 +159,7 @@ async fn test_tool_agent_complex_math() {
         match result {
             Ok(update) => {
                 println!("[{}] {}", update.event_type, update.message);
-                if update.event_type == "final_result" {
+                if update.is_final_result() {
                     if let Some(result) = update.as_final_result() {
                         final_answer = result.result.as_str().unwrap_or("").to_string();
                     }
@@ -207,7 +207,7 @@ async fn test_tool_agent_current_datetime() {
         match result {
             Ok(update) => {
                 println!("[{}] {}", update.event_type, update.message);
-                if update.event_type == "final_result" {
+                if update.is_final_result() {
                     if let Some(result) = update.as_final_result() {
                         final_answer = result.result.as_str().unwrap_or("").to_string();
                     }
@@ -250,7 +250,7 @@ async fn test_tool_agent_multiple_tools() {
         match result {
             Ok(update) => {
                 println!("[{}] {}", update.event_type, update.message);
-                if update.event_type == "final_result" {
+                if update.is_final_result() {
                     if let Some(result) = update.as_final_result() {
                         final_answer = result.result.as_str().unwrap_or("").to_string();
                     }

--- a/gemicro-core/src/agent/mod.rs
+++ b/gemicro-core/src/agent/mod.rs
@@ -697,7 +697,7 @@ mod tests {
         assert_eq!(collected.len(), 3);
         assert!(collected[0].as_ref().unwrap().event_type == "step_1");
         assert!(collected[1].as_ref().unwrap().event_type == "step_2");
-        assert!(collected[2].as_ref().unwrap().event_type == "final_result");
+        assert!(collected[2].as_ref().unwrap().is_final_result());
     }
 
     /// Verifies that events after final_result still pass through (with warning logged).
@@ -787,7 +787,7 @@ mod tests {
         }
 
         assert_eq!(collected.len(), 1);
-        assert!(collected[0].as_ref().unwrap().event_type == "final_result");
+        assert!(collected[0].as_ref().unwrap().is_final_result());
     }
 
     /// Verifies the EVENT_FINAL_RESULT constant matches the expected value.
@@ -829,9 +829,9 @@ mod tests {
         // All events should still pass through (graceful degradation)
         assert_eq!(collected.len(), 4);
         assert!(collected[0].as_ref().unwrap().event_type == "step_1");
-        assert!(collected[1].as_ref().unwrap().event_type == "final_result");
-        assert!(collected[2].as_ref().unwrap().event_type == "final_result");
-        assert!(collected[3].as_ref().unwrap().event_type == "final_result");
+        assert!(collected[1].as_ref().unwrap().is_final_result());
+        assert!(collected[2].as_ref().unwrap().is_final_result());
+        assert!(collected[3].as_ref().unwrap().is_final_result());
         // Note: Warnings are logged for collected[2] and collected[3] but we can't easily verify logs
     }
 


### PR DESCRIPTION
## Summary

Implements RFC #202 - Core Type Ergonomic Accessors, adding convenience methods to core types for improved developer ergonomics.

### Changes

**FinalResult**
- `result_as<T>()` - Generic typed deserialization of agent results

**AgentUpdate**
- `is_final_result()` - Check event type using `EVENT_FINAL_RESULT` constant (avoids string literal typos)
- Refactored `as_final_result()` to use `is_final_result()` internally

**AgentError**
- `is_retriable()` - Check for transient failures (timeouts, rate limits) that may succeed on retry
- `is_timeout()` - Check for timeout errors
- `is_cancelled()` - Check for cancellation

### Usage Updates

- CritiqueAgent now uses `result_as::<CritiqueOutput>()` instead of `serde_json::from_value()`
- Tool-agent integration tests use `is_final_result()` instead of string comparison
- Core contract tests updated to use `is_final_result()`

## Test plan

- [x] All existing tests pass (`make check`)
- [x] New unit tests for `is_final_result()`, `result_as()`, `is_retriable()`, `is_timeout()`, `is_cancelled()`
- [x] Parameterized tests using `rstest` for error query methods

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)