### PR TITLE
feat(agents): Add EchoAgent for CLI integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "agents/gemicro-tool-agent",
     "agents/gemicro-critique",
     "agents/gemicro-developer",
+    "agents/gemicro-echo",
     "tools/gemicro-file-read",
     "tools/gemicro-web-fetch",
     "tools/gemicro-task",

--- a/agents/gemicro-echo/Cargo.toml
+++ b/agents/gemicro-echo/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "gemicro-echo"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Echo agent: minimal no-LLM agent for CLI integration testing"
+
+[dependencies]
+gemicro-core = { path = "../../gemicro-core" }
+async-stream = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util", "macros"] }
+futures-util = { workspace = true }
+rust-genai = { workspace = true }

--- a/agents/gemicro-echo/src/lib.rs
+++ b/agents/gemicro-echo/src/lib.rs
@@ -1,0 +1,137 @@
+//! Echo Agent - A minimal agent for CLI integration testing.
+//!
+//! This agent echoes the input query without making any LLM calls, enabling:
+//! - **Fast tests**: No network latency or API costs
+//! - **Deterministic output**: Always returns predictable results
+//! - **Decoupled testing**: CLI validation doesn't depend on specific agent behavior
+//!
+//! # Example
+//!
+//! ```
+//! use gemicro_echo::EchoAgent;
+//! use gemicro_core::{Agent, AgentContext, LlmClient, LlmConfig};
+//! use futures_util::StreamExt;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let agent = EchoAgent;
+//!
+//! let genai = rust_genai::Client::builder("unused".to_string()).build();
+//! let context = AgentContext::new(LlmClient::new(genai, LlmConfig::default()));
+//!
+//! let stream = agent.execute("Hello, world!", context);
+//! futures_util::pin_mut!(stream);
+//!
+//! while let Some(update) = stream.next().await {
+//!     let update = update?;
+//!     if let Some(result) = update.as_final_result() {
+//!         let answer = result.result.as_str().unwrap_or("");
+//!         assert!(answer.contains("Hello, world!"));
+//!     }
+//! }
+//! # Ok(())
+//! # }
+//! ```
+
+use async_stream::try_stream;
+use gemicro_core::{Agent, AgentContext, AgentStream, AgentUpdate, DefaultTracker, ResultMetadata};
+use serde_json::json;
+
+/// A minimal agent that echoes input without LLM calls.
+///
+/// Designed for CLI integration testing where we want to verify:
+/// - CLI argument parsing works correctly
+/// - Agent execution pipeline functions end-to-end
+/// - Output formatting and rendering behaves as expected
+///
+/// Does not require API keys or network access.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EchoAgent;
+
+impl Agent for EchoAgent {
+    fn name(&self) -> &str {
+        "echo"
+    }
+
+    fn description(&self) -> &str {
+        "Echoes input without LLM calls (for testing)"
+    }
+
+    fn execute(&self, query: &str, _context: AgentContext) -> AgentStream<'_> {
+        let query = query.to_string();
+
+        Box::pin(try_stream! {
+            // Emit final result immediately - no processing needed
+            let answer = format!("Echo: {}", query);
+            yield AgentUpdate::final_result(
+                json!(answer),
+                ResultMetadata::new(0, 0, 0),
+            );
+        })
+    }
+
+    fn create_tracker(&self) -> Box<dyn gemicro_core::ExecutionTracking> {
+        Box::new(DefaultTracker::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::StreamExt;
+    use gemicro_core::{LlmClient, LlmConfig};
+
+    #[test]
+    fn test_agent_name() {
+        let agent = EchoAgent;
+        assert_eq!(agent.name(), "echo");
+    }
+
+    #[test]
+    fn test_agent_description() {
+        let agent = EchoAgent;
+        assert!(!agent.description().is_empty());
+        assert!(agent.description().contains("test"));
+    }
+
+    #[tokio::test]
+    async fn test_echo_output() {
+        let agent = EchoAgent;
+
+        let genai = rust_genai::Client::builder("unused".to_string()).build();
+        let context = AgentContext::new(LlmClient::new(genai, LlmConfig::default()));
+
+        let stream = agent.execute("Hello, world!", context);
+        futures_util::pin_mut!(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.expect("should not error"));
+        }
+
+        // Should emit exactly one event: final_result
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, "final_result");
+
+        // Verify echo content
+        let result = events[0].as_final_result().expect("should be final_result");
+        let answer = result.result.as_str().unwrap_or("");
+        assert!(answer.contains("Echo: Hello, world!"));
+    }
+
+    #[tokio::test]
+    async fn test_zero_tokens() {
+        let agent = EchoAgent;
+
+        let genai = rust_genai::Client::builder("unused".to_string()).build();
+        let context = AgentContext::new(LlmClient::new(genai, LlmConfig::default()));
+
+        let stream = agent.execute("test", context);
+        futures_util::pin_mut!(stream);
+
+        let event = stream.next().await.unwrap().unwrap();
+        let result = event.as_final_result().unwrap();
+
+        // No LLM calls = zero tokens
+        assert_eq!(result.metadata.total_tokens, 0);
+    }
+}

--- a/gemicro-cli/Cargo.toml
+++ b/gemicro-cli/Cargo.toml
@@ -15,6 +15,7 @@ gemicro-runner = { path = "../gemicro-runner" }
 # Agent crates - CLI needs all agents it uses
 gemicro-deep-research = { path = "../agents/gemicro-deep-research" }
 gemicro-developer = { path = "../agents/gemicro-developer" }
+gemicro-echo = { path = "../agents/gemicro-echo" }
 gemicro-react = { path = "../agents/gemicro-react" }
 gemicro-simple-qa = { path = "../agents/gemicro-simple-qa" }
 gemicro-tool-agent = { path = "../agents/gemicro-tool-agent" }

--- a/gemicro-cli/src/repl/session.rs
+++ b/gemicro-cli/src/repl/session.rs
@@ -17,6 +17,7 @@ use gemicro_core::{
 };
 use gemicro_deep_research::DeepResearchAgent;
 use gemicro_developer::{DeveloperAgent, DeveloperConfig};
+use gemicro_echo::EchoAgent;
 use gemicro_runner::AgentRegistry;
 use gemicro_tool_agent::{ToolAgent, ToolAgentConfig};
 use rustyline::error::ReadlineError;
@@ -216,6 +217,9 @@ impl Session {
                     .expect("default config should not fail"),
             )
         });
+
+        // Register echo agent (no config needed - for testing)
+        self.registry.register("echo", || Box::new(EchoAgent));
     }
 
     /// Reload configuration from files.

--- a/gemicro-cli/tests/cli_integration.rs
+++ b/gemicro-cli/tests/cli_integration.rs
@@ -49,7 +49,7 @@ fn test_cli_invalid_temperature() {
     let output = run_cli(&[
         "test query",
         "--agent",
-        "deep_research",
+        "echo",
         "--api-key",
         "fake-key",
         "--temperature",
@@ -65,7 +65,7 @@ fn test_cli_invalid_min_max_queries() {
     let output = run_cli(&[
         "test query",
         "--agent",
-        "deep_research",
+        "echo",
         "--api-key",
         "fake-key",
         "--min-sub-queries",
@@ -83,7 +83,7 @@ fn test_cli_zero_timeout() {
     let output = run_cli(&[
         "test query",
         "--agent",
-        "deep_research",
+        "echo",
         "--api-key",
         "fake-key",
         "--timeout",
@@ -99,7 +99,7 @@ fn test_cli_llm_timeout_exceeds_total() {
     let output = run_cli(&[
         "test query",
         "--agent",
-        "deep_research",
+        "echo",
         "--api-key",
         "fake-key",
         "--timeout",
@@ -234,13 +234,7 @@ fn test_cli_interactive_help() {
 fn test_cli_interactive_no_query_required() {
     // Interactive mode should not require a query argument
     // This will fail on missing API key, but that's expected
-    let output = run_cli(&[
-        "--interactive",
-        "--agent",
-        "deep_research",
-        "--api-key",
-        "fake-key",
-    ]);
+    let output = run_cli(&["--interactive", "--agent", "echo", "--api-key", "fake-key"]);
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     // Should NOT fail with "Query is required"


### PR DESCRIPTION
## Summary
- Add `gemicro-echo` crate with minimal `EchoAgent` that echoes input without LLM calls
- Register echo agent in CLI's agent registry
- Update CLI validation tests to use `--agent echo` for faster, deterministic testing

## Benefits
- **Faster tests**: No LLM calls, instant responses
- **Deterministic**: Always returns predictable output  
- **Decoupled**: CLI tests don't depend on specific agent behavior

## Test plan
- [x] `make check` passes (fmt, clippy, tests)
- [x] EchoAgent unit tests verify correct behavior
- [x] CLI validation tests use echo agent and pass
- [x] `#[ignore]` tests with real agents preserved for E2E coverage

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)