### PR TITLE
chore: Add .worktrees to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ Cargo.lock
 # Claude Code
 .claude/
 .parallel-context.md
+.worktrees/


### PR DESCRIPTION
## Summary
- Add `.worktrees/` to `.gitignore` to prevent git worktree directories from being tracked

This prevents accidental commits of embedded git repositories when using `/parallel-work`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)