### PR TITLE
feat(developer): Phase 3 - LLM-driven self-validation via CritiqueAgent (#221)

### DIFF
--- a/agents/gemicro-developer/Cargo.toml
+++ b/agents/gemicro-developer/Cargo.toml
@@ -19,13 +19,14 @@ log = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
+gemicro-bash = { path = "../../tools/gemicro-bash" }
+gemicro-critique = { path = "../gemicro-critique" }
+gemicro-deep-research = { path = "../gemicro-deep-research" }
 gemicro-file-read = { path = "../../tools/gemicro-file-read" }
 gemicro-glob = { path = "../../tools/gemicro-glob" }
 gemicro-grep = { path = "../../tools/gemicro-grep" }
-gemicro-bash = { path = "../../tools/gemicro-bash" }
-gemicro-task = { path = "../../tools/gemicro-task" }
 gemicro-runner = { path = "../../gemicro-runner" }
-gemicro-deep-research = { path = "../gemicro-deep-research" }
+gemicro-task = { path = "../../tools/gemicro-task" }
 gemicro-tool-agent = { path = "../gemicro-tool-agent" }
 tokio-util = { workspace = true }
 textwrap = "0.16"

--- a/agents/gemicro-developer/examples/subagent_delegation.rs
+++ b/agents/gemicro-developer/examples/subagent_delegation.rs
@@ -9,6 +9,10 @@
 //!   GEMINI_API_KEY=your_key cargo run -p gemicro-developer --example subagent_delegation -- \
 //!     "Research the tradeoffs between tokio and async-std"
 //!
+//! Self-critique example (validates work against conventions):
+//!   GEMINI_API_KEY=your_key cargo run -p gemicro-developer --example subagent_delegation -- \
+//!     "Review the changes in src/lib.rs and validate against project conventions"
+//!
 //! For full wire-level debugging:
 //!   LOUD_WIRE=1 GEMINI_API_KEY=your_key cargo run -p gemicro-developer --example subagent_delegation
 
@@ -16,6 +20,7 @@ use futures_util::StreamExt;
 use gemicro_bash::Bash;
 use gemicro_core::tool::{AutoApprove, ToolRegistry};
 use gemicro_core::{Agent, AgentContext, LlmClient, LlmConfig, MODEL};
+use gemicro_critique::CritiqueAgent;
 use gemicro_deep_research::{DeepResearchAgent, ResearchConfig};
 use gemicro_developer::{DeveloperAgent, DeveloperConfig};
 use gemicro_file_read::FileRead;
@@ -106,6 +111,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let tool_config = ToolAgentConfig::default();
         reg.register("tool_agent", move || {
             Box::new(ToolAgent::new(tool_config.clone()).unwrap()) as Box<dyn Agent>
+        });
+
+        // Critique agent for self-validation against project conventions
+        reg.register("critique", || {
+            Box::new(CritiqueAgent::default_agent()) as Box<dyn Agent>
         });
 
         println!("Registered agents:");

--- a/agents/gemicro-developer/prompts/developer_system.md
+++ b/agents/gemicro-developer/prompts/developer_system.md
@@ -118,12 +118,14 @@ When the `task` tool is available, you can delegate work to specialized subagent
 |-------|---------|
 | `deep_research` | Complex research requiring multiple sub-queries synthesized into a comprehensive answer |
 | `tool_agent` | Tasks requiring tool use without the full developer workflow (simpler, faster) |
+| `critique` | Validate your work against project conventions (CLAUDE.md), check for issues before completing |
 
 *Note: Other registered agents may also be available. These are the commonly useful subagents.*
 
 **When to delegate:**
 - Research questions needing synthesis of multiple sources → `deep_research`
 - Simple tool-based tasks you could do yourself but want isolated → `tool_agent`
+- Self-validation before completing significant changes → `critique`
 
 **When NOT to delegate:**
 - Tasks you can handle directly with available tools
@@ -139,3 +141,35 @@ When the `task` tool is available, you can delegate work to specialized subagent
   }
 }
 ```
+
+## Self-Validation
+
+Before completing significant changes, consider validating your work:
+
+**When to self-validate:**
+- After making multiple file edits
+- Before declaring a task complete
+- When implementing features that must follow project conventions
+
+**How to validate:**
+Use the `critique` agent to check your changes against project conventions:
+
+```json
+{
+  "tool": "task",
+  "input": {
+    "agent": "critique",
+    "query": "Review the changes I made to src/agent.rs for adherence to CLAUDE.md conventions"
+  }
+}
+```
+
+**What critique checks:**
+- Adherence to project-specific conventions (from CLAUDE.md)
+- Code quality issues and anti-patterns
+- Consistency with existing codebase patterns
+
+**When NOT to validate:**
+- Simple one-line fixes
+- Changes that don't involve project-specific conventions
+- When the user explicitly wants quick iteration without validation

--- a/gemicro-cli/Cargo.toml
+++ b/gemicro-cli/Cargo.toml
@@ -13,6 +13,7 @@ gemicro-core = { path = "../gemicro-core" }
 gemicro-runner = { path = "../gemicro-runner" }
 
 # Agent crates - CLI needs all agents it uses
+gemicro-critique = { path = "../agents/gemicro-critique" }
 gemicro-deep-research = { path = "../agents/gemicro-deep-research" }
 gemicro-developer = { path = "../agents/gemicro-developer" }
 gemicro-echo = { path = "../agents/gemicro-echo" }

--- a/gemicro-cli/src/repl/session.rs
+++ b/gemicro-cli/src/repl/session.rs
@@ -15,6 +15,7 @@ use gemicro_core::{
     enforce_final_result_contract, tool::ToolRegistry, AgentContext, AgentError, AgentUpdate,
     BatchConfirmationHandler, ConversationHistory, HistoryEntry, LlmClient,
 };
+use gemicro_critique::CritiqueAgent;
 use gemicro_deep_research::DeepResearchAgent;
 use gemicro_developer::{DeveloperAgent, DeveloperConfig};
 use gemicro_echo::EchoAgent;
@@ -268,6 +269,9 @@ impl Session {
 
         // Register echo agent (no config needed - for testing)
         registry.register("echo", || Box::new(EchoAgent));
+
+        // Register critique agent (for self-validation via Task tool)
+        registry.register("critique", || Box::new(CritiqueAgent::default_agent()));
     }
 
     /// Reload configuration from files.


### PR DESCRIPTION
## Summary

Enable DeveloperAgent to validate its own work by calling CritiqueAgent through the Task tool. Following Evergreen principles, this uses LLM judgment rather than forced checkpoints.

**Changes:**
- Register CritiqueAgent in CLI's default AgentRegistry
- Add `critique` to subagent delegation table in developer prompt
- Add "Self-Validation" section with guidance on when to validate
- Update subagent_delegation example to include CritiqueAgent

**Philosophy:**
Per `agents/gemicro-developer/CLAUDE.md`: "Don't build code to do what the LLM already does well." The LLM decides when validation is appropriate (e.g., after multiple edits, before completing significant tasks) rather than infrastructure forcing validation checkpoints.

## Test Plan

- [x] `make check` passes (fmt, clippy, tests)
- [x] CLI shows `critique` in available agents list
- [x] Example compiles with CritiqueAgent registration

## Closes

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)