### PR TITLE
feat(core): Add Turn array support to LlmRequest

### DIFF
--- a/gemicro-core/src/lib.rs
+++ b/gemicro-core/src/lib.rs
@@ -70,7 +70,7 @@ pub use config::{GemicroConfig, LlmConfig, MODEL};
 pub use context::{ContextLevel, ContextUsage, DEFAULT_CONTEXT_WINDOW, DEFAULT_WARNING_THRESHOLD};
 pub use error::{AgentError, GemicroError, LlmError};
 pub use history::{ConversationHistory, HistoryEntry};
-pub use llm::{LlmClient, LlmRequest, LlmStreamChunk};
+pub use llm::{LlmClient, LlmRequest, LlmStreamChunk, Role, Turn, TurnContent};
 pub use mock_llm::MockLlmClient;
 pub use tool::{
     tools_to_callables, AutoApprove, AutoDeny, BatchApproval, BatchConfirmationHandler,

--- a/gemicro-core/src/llm/mod.rs
+++ b/gemicro-core/src/llm/mod.rs
@@ -31,3 +31,6 @@ mod request;
 
 pub use client::LlmClient;
 pub use request::{LlmRequest, LlmStreamChunk};
+
+// Re-export Turn types from rust-genai for multi-turn conversation support
+pub use rust_genai::{Role, Turn, TurnContent};

--- a/gemicro-core/src/mock_llm.rs
+++ b/gemicro-core/src/mock_llm.rs
@@ -222,6 +222,7 @@ mod tests {
             phase: "test".to_string(),
             request: SerializableLlmRequest {
                 prompt: "What is 2+2?".to_string(),
+                turns: None,
                 system_instruction: None,
                 use_google_search: false,
                 response_format: None,
@@ -241,6 +242,7 @@ mod tests {
             phase: "streaming".to_string(),
             request: SerializableLlmRequest {
                 prompt: "Count to 3".to_string(),
+                turns: None,
                 system_instruction: None,
                 use_google_search: false,
                 response_format: None,
@@ -437,6 +439,7 @@ mod tests {
             phase: "timed".to_string(),
             request: SerializableLlmRequest {
                 prompt: "Count".to_string(),
+                turns: None,
                 system_instruction: None,
                 use_google_search: false,
                 response_format: None,

--- a/gemicro-core/src/trajectory/builder.rs
+++ b/gemicro-core/src/trajectory/builder.rs
@@ -135,6 +135,7 @@ mod tests {
     fn sample_request() -> SerializableLlmRequest {
         SerializableLlmRequest {
             prompt: "Test prompt".to_string(),
+            turns: None,
             system_instruction: None,
             use_google_search: false,
             response_format: None,


### PR DESCRIPTION
## Summary

- Adds `turns: Option<Vec<Turn>>` field to `LlmRequest` for multi-turn conversation support
- Provides `with_turns()` builder method for setting conversation history
- Re-exports `Turn`, `Role`, `TurnContent` from rust-genai for ergonomic access
- Serializes turns to JSON in trajectory recording for replay support
- Wires turns through `build_interaction()` - appends current prompt as final user turn

## Test plan

- [x] Unit tests for `LlmRequest` builder methods with turns
- [x] Unit tests for `SerializableLlmRequest` conversion with turns
- [x] Trajectory round-trip test verifying turns survive save/load
- [x] All-options test combining turns with system, google search, response format
- [x] Integration test `test_generate_with_turns` (requires API key)
- [x] `make check` passes (format, clippy, 313+ tests)

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)